### PR TITLE
Switch to OpenJDK in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: scala
 dist: trusty
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8
+  - oraclejdk11
+  - openjdk8
+  - openjdk11
 sudo: false
 scala:
   - 2.12.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: scala
 dist: trusty
 jdk:
-  - oraclejdk8
-  - oraclejdk11
   - openjdk8
   - openjdk11
 sudo: false


### PR DESCRIPTION
This expands the Travis configuration to also run the tests on the OpenJDK and also to Java11 (for both Oracle and OpenJDK).

If the "oraclejdk8" test can be dropped, it would also easily be possible to switch to a newer OS base image. Travis' installer for JDKs seems to be unable to install "oraclejdk8" on newer releases. It's also debatable if the Oracle JDK 11 is relevant, so ideally we could only go with "openjdk8" and "openjdk11" and a newer OS version.