### PR TITLE
Decorrelate routes from registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ import fr.davit.akka.http.metrics.prometheus.PrometheusRegistry
 val settings: HttpMetricsSettings = ... // your http metrics settings
 val prometheus: CollectorRegistry = ... // your prometheus registry
 
-val registry = PrometheusRegistry(settings, prometheus) // or PrometheusRegistry(settings) to use the default registry
+val registry = PrometheusRegistry(prometheus, settings) // or PrometheusRegistry(settings = settings) to use the default registry
 ```
 
 Expose the metrics

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The status group labels creates the following dimensions on the metrics: `1xx|2x
 
 ##### Path
 
-The path labels creates uses the path of the request as dimension on the metrics.
+The path labels uses the path of the request as dimension on the metrics.
 
 When enabling this dimension, you must be careful about cardinality: see [here](https://prometheus.io/docs/practices/naming/#labels).
 If your path is contains unbounded dynamic segments, you must use the labeled path directives defined in `HttpMetricsDirectives`:

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val `akka-http-metrics-datadog` = (project in file("datadog"))
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.datadog,
+      Dependencies.Provided.akkaStream,
       Dependencies.Test.akkaHttpTestkit,
       Dependencies.Test.akkaStreamTestkit,
       Dependencies.Test.akkaSlf4j,

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val commonSettings = Defaults.itSettings ++
   Seq(
   organization := "fr.davit",
   organizationName := "Michel Davit",
-  version := "0.7.0-SNAPSHOT",
+  version := "1.0.0-SNAPSHOT",
   crossScalaVersions := Seq("2.12.10", "2.13.1"),
   scalaVersion := crossScalaVersions.value.last,
   Compile / compile / scalacOptions ++= Settings.scalacOptions(scalaVersion.value),

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsHandler.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsHandler.scala
@@ -1,0 +1,13 @@
+package fr.davit.akka.http.metrics.core
+
+import akka.Done
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait HttpMetricsHandler {
+
+  def onRequest(request: HttpRequest, response: Future[HttpResponse])(implicit executionContext: ExecutionContext): Unit
+
+  def onConnection(completion: Future[Done])(implicit executionContext: ExecutionContext): Unit
+}

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsHandler.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsHandler.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.core
 
 import akka.Done

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
@@ -65,27 +65,27 @@ trait HttpMetricsRegistry {
   //--------------------------------------------------------------------------------------------------------------------
   // requests
   //--------------------------------------------------------------------------------------------------------------------
-  def active: Gauge[Long]
+  def active: Gauge
 
-  def requests: Counter[Long]
+  def requests: Counter
 
-  def receivedBytes: Histogram[Long]
+  def receivedBytes: Histogram
 
   //--------------------------------------------------------------------------------------------------------------------
   // responses
   //--------------------------------------------------------------------------------------------------------------------
-  def responses: Counter[Long]
+  def responses: Counter
 
-  def errors: Counter[Long]
+  def errors: Counter
 
   def duration: Timer
 
-  def sentBytes: Histogram[Long]
+  def sentBytes: Histogram
 
   //--------------------------------------------------------------------------------------------------------------------
   // Connections
   //--------------------------------------------------------------------------------------------------------------------
-  def connected: Gauge[Long]
+  def connected: Gauge
 
-  def connections: Counter[Long]
+  def connections: Counter
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/Metrics.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/Metrics.scala
@@ -23,11 +23,11 @@ trait Dimension {
   def value: String
 }
 
-trait Counter[T] {
+trait Counter {
   def inc(dimensions: Seq[Dimension] = Seq.empty): Unit
 }
 
-trait Gauge[T] {
+trait Gauge {
   def inc(dimensions: Seq[Dimension] = Seq.empty): Unit
 
   def dec(dimensions: Seq[Dimension] = Seq.empty): Unit
@@ -37,6 +37,6 @@ trait Timer {
   def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit
 }
 
-trait Histogram[T] {
-  def update(value: T, dimensions: Seq[Dimension] = Seq.empty): Unit
+trait Histogram {
+  def update[T: Numeric](value: T, dimensions: Seq[Dimension] = Seq.empty): Unit
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/scaladsl/model/headers.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/scaladsl/model/headers.scala
@@ -21,26 +21,39 @@ import akka.http.scaladsl.model.headers.{ModeledCustomHeader, ModeledCustomHeade
 import scala.util.Try
 
 private[core] final case class PathLabelHeader(label: String) extends ModeledCustomHeader[PathLabelHeader] {
-  override def renderInRequests  = true
-  override def renderInResponses = true
-  override val companion         = PathLabelHeader
-  override def value: String     = label
+  override def renderInRequests = false
+
+  override def renderInResponses = false
+
+  override val companion = PathLabelHeader
+
+  override def value: String = label
 }
 
 private[core] object PathLabelHeader extends ModeledCustomHeaderCompanion[PathLabelHeader] {
-  override val name                 = "x-path-label"
-  override def parse(value: String) = Try(PathLabelHeader(value))
+  override val name = "x-path-label"
+
+  override def parse(value: String) = Try(new PathLabelHeader(value))
 }
 
 private[core] final case class SegmentLabelHeader(from: Int, to: Int, label: String)
     extends ModeledCustomHeader[SegmentLabelHeader] {
-  override def renderInRequests  = true
-  override def renderInResponses = true
-  override val companion         = SegmentLabelHeader
-  override def value: String     = s"$from:$to:$label"
+  override def renderInRequests = false
+
+  override def renderInResponses = false
+
+  override val companion = SegmentLabelHeader
+
+  override def value: String = s"$from:$to:$label"
 }
 
 private[core] object SegmentLabelHeader extends ModeledCustomHeaderCompanion[SegmentLabelHeader] {
-  override val name                 = "x-segment-label"
-  override def parse(value: String) = Try(SegmentLabelHeader(value))
+  override val name = "x-segment-label"
+
+  override def parse(value: String) = Try {
+    value.split(":") match {
+      case Array(from, to, label) => new SegmentLabelHeader(from.toInt, to.toInt, label)
+      case _                      => throw new IllegalArgumentException(s"Invalid SegmentLabelHeader $value")
+    }
+  }
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/scaladsl/server/HttpMetricsRoute.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/scaladsl/server/HttpMetricsRoute.scala
@@ -17,17 +17,15 @@
 package fr.davit.akka.http.metrics.core.scaladsl.server
 
 import akka.NotUsed
-import akka.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route, RoutingLog}
 import akka.http.scaladsl.settings.{ParserSettings, RoutingSettings}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{PathDimension, StatusGroupDimension}
-import fr.davit.akka.http.metrics.core.scaladsl.model.{PathLabelHeader, SegmentLabelHeader}
+import fr.davit.akka.http.metrics.core.HttpMetricsHandler
+import fr.davit.akka.http.metrics.core.scaladsl.model.PathLabelHeader
 
-import scala.concurrent.duration.Deadline
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 object HttpMetricsRoute {
 
@@ -41,67 +39,7 @@ object HttpMetricsRoute {
   */
 class HttpMetricsRoute private (route: Route) extends HttpMetricsDirectives {
 
-  private def buildPathLabel(
-      path: Uri.Path,
-      pathLabel: Option[PathLabelHeader],
-      segmentLabels: List[SegmentLabelHeader]
-  ): PathDimension = {
-    import fr.davit.akka.http.metrics.core.scaladsl.model.Extensions._
-    pathLabel match {
-      case Some(label) =>
-        PathDimension(label.value)
-      case None =>
-        val builder = new StringBuilder()
-        val (rest, _) = segmentLabels.foldLeft((path, 0)) {
-          case ((r, idx), l) =>
-            builder.append(r.take(l.from - idx))
-            builder.append(l.label)
-            (r.drop(l.to - idx), l.to)
-        }
-        builder.append(rest)
-        PathDimension(builder.result())
-    }
-  }
-
-  private def metricsHandler(
-      registry: HttpMetricsRegistry,
-      settings: HttpMetricsSettings,
-      handler: HttpRequest => Future[HttpResponse]
-  )(request: HttpRequest)(
-      implicit
-      executionContext: ExecutionContext
-  ): Future[HttpResponse] = {
-    registry.active.inc()
-    registry.requests.inc()
-    registry.receivedBytes.update(request.entity.contentLengthOption.getOrElse(0L))
-    val start    = Deadline.now
-    val response = handler(request)
-    // no need to handle failures at this point. They will fail the stream hence the server
-    response.map { r =>
-      // extract custom segment headers
-      val (pathLabel, segmentLabels, headers) = r.headers
-        .foldLeft[(Option[PathLabelHeader], List[SegmentLabelHeader], List[HttpHeader])]((None, Nil, Nil)) {
-          case ((_, sls, hs), h: PathLabelHeader)     => (Some(h), sls, hs)
-          case ((pl, sls, hs), h: SegmentLabelHeader) => (pl, h :: sls, hs)
-          case ((pl, sls, hs), h: HttpHeader)         => (pl, sls, h :: hs)
-        }
-
-      // compute dimensions
-      val statusGroupDim = if (settings.includeStatusDimension) Some(StatusGroupDimension(r.status)) else None
-      val pathDim =
-        if (settings.includePathDimension) Some(buildPathLabel(request.uri.path, pathLabel, segmentLabels)) else None
-      val dimensions = statusGroupDim.toSeq ++ pathDim
-
-      registry.active.dec()
-      registry.responses.inc(dimensions)
-      registry.duration.observe(Deadline.now - start, dimensions)
-      if (settings.defineError(r)) registry.errors.inc(dimensions)
-      r.entity.contentLengthOption.foreach(registry.sentBytes.update(_, dimensions))
-      r.withHeaders(headers) // clean the custom headers
-    }
-  }
-
-  def recordMetrics(registry: HttpMetricsRegistry, settings: HttpMetricsSettings = HttpMetricsSettings.default)(
+  def recordMetrics(metricsHandler: HttpMetricsHandler)(
       implicit
       routingSettings: RoutingSettings,
       parserSettings: ParserSettings,
@@ -111,7 +49,6 @@ class HttpMetricsRoute private (route: Route) extends HttpMetricsDirectives {
       rejectionHandler: RejectionHandler = RejectionHandler.default,
       exceptionHandler: ExceptionHandler = null
   ): Flow[HttpRequest, HttpResponse, NotUsed] = {
-
     // override the execution context passed as parameter and the rejection handler
     val effectiveEC               = if (executionContext ne null) executionContext else materializer.executionContext
     val effectiveRejectionHandler = rejectionHandler.mapRejectionResponse(_.addHeader(new PathLabelHeader("unhandled")))
@@ -120,19 +57,17 @@ class HttpMetricsRoute private (route: Route) extends HttpMetricsDirectives {
       implicit val executionContext: ExecutionContextExecutor = effectiveEC
       implicit val rejectionHandler: RejectionHandler         = effectiveRejectionHandler
       Flow[HttpRequest]
-        .mapAsync(1)(recordMetricsAsync(registry, settings))
+        .mapAsync(1)(recordMetricsAsync(metricsHandler))
         .watchTermination() {
           case (mat, completion) =>
             // every connection materializes a stream
-            registry.connections.inc()
-            registry.connected.inc()
-            completion.onComplete(_ => registry.connected.dec())
+            metricsHandler.onConnection(completion)
             mat
         }
     }
   }
 
-  def recordMetricsAsync(registry: HttpMetricsRegistry, settings: HttpMetricsSettings = HttpMetricsSettings.default)(
+  def recordMetricsAsync(metricsHandler: HttpMetricsHandler)(
       implicit
       routingSettings: RoutingSettings,
       parserSettings: ParserSettings,
@@ -141,7 +76,9 @@ class HttpMetricsRoute private (route: Route) extends HttpMetricsDirectives {
       executionContext: ExecutionContextExecutor = null,
       rejectionHandler: RejectionHandler = RejectionHandler.default,
       exceptionHandler: ExceptionHandler = null
-  ): HttpRequest => Future[HttpResponse] = {
-    metricsHandler(registry, settings, Route.asyncHandler(route))
+  ): HttpRequest => Future[HttpResponse] = { request =>
+    val response = Route.asyncHandler(route).apply(request)
+    metricsHandler.onRequest(request, response)
+    response
   }
 }

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
@@ -1,0 +1,144 @@
+package fr.davit.akka.http.metrics.core
+
+import java.util.concurrent.Executor
+
+import akka.Done
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.StatusGroupDimension.StatusGroup
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{PathDimension, StatusGroupDimension}
+import fr.davit.akka.http.metrics.core.scaladsl.model.{PathLabelHeader, SegmentLabelHeader}
+import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsSettings
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually {
+
+  implicit val currentThreadExecutionContext = ExecutionContext.fromExecutor(
+    new Executor {
+      override def execute(runnable: Runnable) { runnable.run() }
+    }
+  )
+
+  abstract class Fixture(settings: HttpMetricsSettings = HttpMetricsSettings.default) {
+    val registry = new TestRegistry(settings)
+  }
+
+  "HttpMetricsRegistry" should "compute the number of requests" in new Fixture() {
+    registry.requests.value() shouldBe 0
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse()))
+    registry.requests.value() shouldBe 1
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse()))
+    registry.requests.value() shouldBe 2
+  }
+
+  it should "compute the number of errors" in new Fixture() {
+    registry.errors.value() shouldBe 0
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.OK)))
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.TemporaryRedirect)))
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.BadRequest)))
+    registry.errors.value() shouldBe 0
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.InternalServerError)))
+    registry.errors.value() shouldBe 1
+  }
+
+  it should "compute the number of active requests" in new Fixture() {
+    registry.active.value() shouldBe 0
+    val promise = Promise[HttpResponse]()
+    registry.onRequest(HttpRequest(), promise.future)
+    registry.onRequest(HttpRequest(), promise.future)
+    registry.active.value() shouldBe 2
+    promise.success(HttpResponse())
+    registry.active.value() shouldBe 0
+  }
+
+  it should "compute the requests time" in new Fixture() {
+    val promise  = Promise[HttpResponse]()
+    val duration = 500.millis
+    registry.duration.values() shouldBe empty
+    registry.onRequest(HttpRequest(), promise.future)
+    Thread.sleep(duration.toMillis)
+    promise.success(HttpResponse())
+    registry.duration.values().head should be > duration
+  }
+
+  it should "compute the requests size" in new Fixture() {
+    val data = "This is the request content"
+    registry.receivedBytes.values() shouldBe empty
+    registry.onRequest(HttpRequest(entity = data), Future.successful(HttpResponse()))
+    registry.receivedBytes.values().head shouldBe data.getBytes.length
+  }
+
+  it should "compute the response size" in new Fixture() {
+    val data = "This is the response content"
+    registry.sentBytes.values() shouldBe empty
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse(entity = data)))
+    registry.sentBytes.values().head shouldBe data.getBytes.length
+  }
+
+  it should "compute the number of connections" in new Fixture() {
+    registry.connections.value() shouldBe 0
+    registry.onConnection(Future.successful(Done))
+    registry.connections.value() shouldBe 1
+    registry.onConnection(Future.failed(new Exception("Stream error")))
+    registry.connections.value() shouldBe 2
+  }
+
+  it should "compute the number of active connections" in new Fixture() {
+    registry.connected.value() shouldBe 0
+    val promise = Promise[Done]()
+    registry.onConnection(promise.future)
+    registry.onConnection(promise.future)
+    registry.connected.value() shouldBe 2
+    promise.success(Done)
+    registry.connected.value() shouldBe 0
+  }
+
+  it should "add status code dimension when enabled" in new Fixture(
+    HttpMetricsSettings.default.withIncludeStatusDimension(true)
+  ) {
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse()))
+    registry.responses.value(Seq(StatusGroupDimension(StatusGroup.`2xx`))) shouldBe 1
+    registry.responses.value(Seq(StatusGroupDimension(StatusGroup.`3xx`))) shouldBe 0
+    registry.responses.value(Seq(StatusGroupDimension(StatusGroup.`4xx`))) shouldBe 0
+    registry.responses.value(Seq(StatusGroupDimension(StatusGroup.`5xx`))) shouldBe 0
+  }
+
+  it should "add path dimension when enabled" in new Fixture(
+    HttpMetricsSettings.default.withIncludePathDimension(true)
+  ) {
+    val path = "/this/is/the/path"
+    registry.onRequest(HttpRequest().withUri(path), Future.successful(HttpResponse()))
+    registry.responses.value(Seq(PathDimension(path))) shouldBe 1
+    registry.responses.value(Seq(PathDimension("/other/path"))) shouldBe 0
+  }
+
+  it should "correctly replace segment labels in path" in new Fixture(
+    HttpMetricsSettings.default.withIncludePathDimension(true)
+  ) {
+    val path = "/this/is/the/path"
+    registry.onRequest(
+      HttpRequest().withUri(path),
+      Future.successful(HttpResponse().withHeaders(SegmentLabelHeader(2, 6, "/label")))
+    )
+    registry.responses.value(Seq(PathDimension("/this/label/path"))) shouldBe 1
+    registry.responses.value(Seq(PathDimension("/other/path"))) shouldBe 0
+  }
+
+  it should "overwrite path dimension when provided" in new Fixture(
+    HttpMetricsSettings.default.withIncludePathDimension(true)
+  ) {
+    val path          = "/this/is/the/path"
+    val overwritePath = "overwrite/path"
+    registry.onRequest(
+      HttpRequest().withUri(path),
+      Future.successful(HttpResponse().withHeaders(PathLabelHeader(overwritePath)))
+    )
+    registry.responses.value(Seq(PathDimension(overwritePath))) shouldBe 1
+    registry.responses.value(Seq(PathDimension("/other/path"))) shouldBe 0
+  }
+
+}

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.core
 
 import java.util.concurrent.Executor

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
@@ -27,7 +27,7 @@ object TestRegistry {
 
   private def keyer(dimensions: Seq[Dimension]): String = dimensions.mkString(":")
 
-  class TestCounter extends Counter[Long] {
+  class TestCounter extends Counter {
     protected val acc = mutable.Map[String, Long]()
 
     override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
@@ -41,7 +41,7 @@ object TestRegistry {
     def value(dimensions: Seq[Dimension] = Seq.empty): Long = acc.getOrElse(keyer(dimensions), 0)
   }
 
-  class TestGauge extends TestCounter with Gauge[Long] {
+  class TestGauge extends TestCounter with Gauge {
     override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
       val key = keyer(dimensions)
       acc.get(key) match {
@@ -65,14 +65,14 @@ object TestRegistry {
     def values(dimensions: Seq[Dimension] = Seq.empty): List[FiniteDuration] = acc.getOrElse(keyer(dimensions), Nil)
   }
 
-  final class TestHistogram extends Histogram[Long] {
+  final class TestHistogram extends Histogram {
     protected val acc = mutable.Map[String, List[Long]]()
 
-    override def update(value: Long, dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    override def update[T](value: T, dimensions: Seq[Dimension] = Seq.empty)(implicit numeric: Numeric[T]): Unit = {
       val key = keyer(dimensions)
       acc.get(key) match {
-        case Some(vs) => acc += (key -> (value :: vs))
-        case None     => acc += (key -> (value :: Nil))
+        case Some(vs) => acc += (key -> (numeric.toLong(value) :: vs))
+        case None     => acc += (key -> (numeric.toLong(value) :: Nil))
       }
     }
 

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
@@ -18,6 +18,7 @@ package fr.davit.akka.http.metrics.core
 
 import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
 import akka.http.scaladsl.model.HttpEntity
+import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsSettings
 
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
@@ -81,7 +82,8 @@ object TestRegistry {
 
 }
 
-final class TestRegistry extends HttpMetricsRegistry {
+final class TestRegistry(settings: HttpMetricsSettings = HttpMetricsSettings.default)
+    extends HttpMetricsRegistry(settings) {
 
   import TestRegistry._
 

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/scaladsl/server/HttpMetricsRouteSpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/scaladsl/server/HttpMetricsRouteSpec.scala
@@ -16,56 +16,48 @@
 
 package fr.davit.akka.http.metrics.core.scaladsl.server
 
+import akka.Done
 import akka.actor.ActorSystem
+import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{Directives, RequestContext, RouteResult}
-import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestKit
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.StatusGroupDimension.StatusGroup
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{PathDimension, StatusGroupDimension}
-import fr.davit.akka.http.metrics.core.TestRegistry
-import fr.davit.akka.http.metrics.core.scaladsl.model.SegmentLabelHeader
+import fr.davit.akka.http.metrics.core.HttpMetricsHandler
+import fr.davit.akka.http.metrics.core.scaladsl.model.PathLabelHeader
 import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsRoute._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ExecutionContext, Future}
 
 class HttpMetricsRouteSpec
     extends TestKit(ActorSystem("HttpMetricsRouteSpec"))
     with AnyFlatSpecLike
     with Matchers
-    with Eventually
-    with ScalaFutures
     with MockFactory
     with BeforeAndAfterAll {
 
   import Directives._
 
-  implicit override val patienceConfig = PatienceConfig(
-    timeout = scaled(Span(500, Millis)),
-    interval = scaled(Span(15, Millis))
-  )
+  abstract class Fixture[T] {
+    val metricsHandler = mock[HttpMetricsHandler]
+    val server         = mockFunction[RequestContext, Future[RouteResult]]
 
-  abstract class Fixture[T](testField: TestRegistry => T, settings: HttpMetricsSettings = HttpMetricsSettings.default) {
-    implicit val registry = new TestRegistry
-
-    val server = mockFunction[RequestContext, Future[RouteResult]]
+    (metricsHandler
+      .onConnection(_: Future[Done])(_: ExecutionContext))
+      .expects(*, *)
+      .returns()
 
     val (source, sink) = TestSource
       .probe[HttpRequest]
-      .via(server.recordMetrics(registry, settings))
+      .via(server.recordMetrics(metricsHandler))
       .toMat(TestSink.probe[HttpResponse])(Keep.both)
       .run()
-
-    def actual: T = testField(registry)
   }
 
   override def afterAll(): Unit = {
@@ -73,181 +65,77 @@ class HttpMetricsRouteSpec
     super.afterAll()
   }
 
-  "HttpMetricsRoute" should "compute the number of requests" in new Fixture(_.requests) {
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.OK))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value() shouldBe 1
+  "HttpMetricsRoute" should "call the metrics handler on connection" in {
+    val metricsHandler = mock[HttpMetricsHandler]
+    val server         = mockFunction[RequestContext, Future[RouteResult]]
+
+    (metricsHandler
+      .onConnection(_: Future[Done])(_: ExecutionContext))
+      .expects(*, *)
+      .returns()
+
+    val (source, sink) = TestSource
+      .probe[HttpRequest]
+      .via(server.recordMetrics(metricsHandler))
+      .toMat(TestSink.probe[HttpResponse])(Keep.both)
+      .run()
 
     sink.request(1)
-    server.expects(*).onCall(reject)
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value() shouldBe 2
-
-    sink.request(1)
-    server.expects(*).onCall(failWith(new Exception("BOOM!")))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value() shouldBe 3
+    source.sendComplete()
+    sink.expectComplete()
   }
 
-  it should "compute the number of errors" in new Fixture(_.errors) {
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.OK))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value() shouldBe 0
+  it should "call the metrics handler on handled requests" in new Fixture {
+    val request  = HttpRequest()
+    val response = Marshal(StatusCodes.OK).to[HttpResponse]
+
+    server
+      .expects(*)
+      .onCall(complete(StatusCodes.OK))
+    (metricsHandler
+      .onRequest(_: HttpRequest, _: Future[HttpResponse])(_: ExecutionContext))
+      .expects(request, response, *)
+      .returns()
 
     sink.request(1)
-    server.expects(*).onCall(reject)
-    source.sendNext(HttpRequest())
+    source.sendNext(request)
     sink.expectNext()
-    actual.value() shouldBe 0
-
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.InternalServerError))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value() shouldBe 1
-
-    sink.request(1)
-    server.expects(*).onCall(failWith(new Exception("BOOM!")))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value() shouldBe 2
   }
 
-  it should "compute the number of active requests" in new Fixture(_.active) {
-    val promise = Promise[StatusCode]()
+  it should "call the metrics handler on rejected requests" in new Fixture {
+    val request = HttpRequest()
+
+    val response = Marshal(StatusCodes.NotFound -> "The requested resource could not be found.")
+      .to[HttpResponse]
+      .map(_.withHeaders(PathLabelHeader("unhandled")))
+
+    server
+      .expects(*)
+      .onCall(reject)
+    (metricsHandler
+      .onRequest(_: HttpRequest, _: Future[HttpResponse])(_: ExecutionContext))
+      .expects(request, response, *)
+      .returns()
 
     sink.request(1)
-    server.expects(*).onCall(complete(promise.future))
-    source.sendNext(HttpRequest())
-
-    // wait for the request to be sent to the handler
-    eventually(actual.value() shouldBe 1)
-
-    promise.success(StatusCodes.OK)
+    source.sendNext(request)
     sink.expectNext()
-    actual.value() shouldBe 0
   }
 
-  it should "compute the requests time" in new Fixture(_.duration) {
-    val promise  = Promise[StatusCode]()
-    val duration = 500.millis
+  it should "call the metrics handler on error requests" in new Fixture {
+    val request  = HttpRequest()
+    val response = Marshal(StatusCodes.InternalServerError).to[HttpResponse]
+
+    server
+      .expects(*)
+      .onCall(failWith(new Exception("BOOM!")))
+    (metricsHandler
+      .onRequest(_: HttpRequest, _: Future[HttpResponse])(_: ExecutionContext))
+      .expects(request, response, *)
+      .returns()
 
     sink.request(1)
-    server.expects(*).onCall(complete(promise.future))
-    source.sendNext(HttpRequest())
-    system.scheduler.scheduleOnce(duration)(promise.success(StatusCodes.OK))(system.dispatcher)
-    sink.expectNext(duration * 2)
-    actual.values().head should be > duration
-  }
-
-  it should "compute the requests size" in new Fixture(_.receivedBytes) {
-    val data = "This is the request content"
-
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.OK))
-    source.sendNext(HttpRequest(entity = HttpEntity(data)))
+    source.sendNext(request)
     sink.expectNext()
-    actual.values().head shouldBe data.getBytes.length
-  }
-
-  it should "compute the response size" in new Fixture(_.sentBytes) {
-    val data = "This is the response content"
-
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.OK -> data))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.values().head shouldBe data.getBytes.length
-  }
-
-  it should "compute the number of active connections" in {
-    implicit val registry = new TestRegistry
-    val server            = mockFunction[RequestContext, Future[RouteResult]]
-
-    val stream = Source.maybe.via(server.recordMetrics(registry)).toMat(Sink.ignore)(Keep.both)
-    val conns  = (0 until 3).map(_ => stream.run())
-    registry.connected.value() shouldBe 3
-
-    conns.map { case (c, _) => c.success(None) }
-    Future.sequence(conns.map { case (_, completion) => completion }).futureValue
-    registry.connected.value() shouldBe 0
-  }
-
-  it should "compute the number of connections" in {
-    implicit val registry = new TestRegistry
-    val server            = mockFunction[RequestContext, Future[RouteResult]]
-
-    val stream =
-      Source((0 until 5).map(_ => HttpRequest())).via(server.recordMetrics(registry)).toMat(Sink.ignore)(Keep.right)
-    val completions = (0 until 3).map(_ => stream.run())
-    Future.sequence(completions).futureValue
-    registry.connections.value() shouldBe 3
-  }
-
-  it should "add status code dimension when enabled" in new Fixture(
-    _.responses,
-    HttpMetricsSettings.default.withIncludeStatusDimension(true)
-  ) {
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.OK))
-    source.sendNext(HttpRequest())
-    sink.expectNext()
-    actual.value(Seq(StatusGroupDimension(StatusGroup.`2xx`))) shouldBe 1
-    actual.value(Seq(StatusGroupDimension(StatusGroup.`3xx`))) shouldBe 0
-    actual.value(Seq(StatusGroupDimension(StatusGroup.`4xx`))) shouldBe 0
-    actual.value(Seq(StatusGroupDimension(StatusGroup.`5xx`))) shouldBe 0
-  }
-
-  it should "add path dimension when enabled" in new Fixture(
-    _.responses,
-    HttpMetricsSettings.default.withIncludePathDimension(true)
-  ) {
-    val path = "/this/is/the/path"
-    sink.request(1)
-    server.expects(*).onCall(complete(StatusCodes.OK))
-    source.sendNext(HttpRequest().withUri(path))
-    sink.expectNext()
-    actual.value(Seq(PathDimension(path))) shouldBe 1
-    actual.value(Seq(PathDimension("/other/path"))) shouldBe 0
-  }
-
-  it should "correctly replace segment labels in path" in new Fixture(
-    _.responses,
-    HttpMetricsSettings.default.withIncludePathDimension(true)
-  ) {
-    val path = "/this/is/the/path"
-    sink.request(1)
-    server.expects(*).onCall(respondWithHeader(SegmentLabelHeader(2, 6, "/label"))(complete(StatusCodes.OK)))
-    source.sendNext(HttpRequest().withUri(path))
-    sink.expectNext()
-    actual.value(Seq(PathDimension("/this/label/path"))) shouldBe 1
-    actual.value(Seq(PathDimension("/other/path"))) shouldBe 0
-  }
-
-  it should "add unhandled path dimension when request is rejected" in new Fixture(
-    _.responses,
-    HttpMetricsSettings.default.withIncludePathDimension(true)
-  ) {
-    val path = "/this/is/the/path"
-    sink.request(1)
-    server.expects(*).onCall(reject)
-    source.sendNext(HttpRequest().withUri(path))
-    sink.expectNext()
-    actual.value(Seq(PathDimension("unhandled"))) shouldBe 1
-    actual.value(Seq(PathDimension(path))) shouldBe 0
-  }
-
-  it should "not leak custom headers" in new Fixture(_.sentBytes) {
-    sink.request(1)
-    server.expects(*).onCall(respondWithHeader(SegmentLabelHeader(0, 1, "/label"))(complete(StatusCodes.OK)))
-    source.sendNext(HttpRequest())
-    val response = sink.expectNext()
-    response.header[SegmentLabelHeader] shouldBe empty
   }
 }

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
@@ -18,17 +18,21 @@ package fr.davit.akka.http.metrics.datadog
 
 import com.timgroup.statsd.StatsDClient
 import fr.davit.akka.http.metrics.core._
+import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsSettings
 
 object DatadogRegistry {
 
-  def apply(client: StatsDClient): DatadogRegistry = new DatadogRegistry()(client)
+  def apply(client: StatsDClient, settings: HttpMetricsSettings = HttpMetricsSettings.default): DatadogRegistry = {
+    new DatadogRegistry(settings)(client)
+  }
 }
 
 /**
   * see [https://docs.datadoghq.com/developers/faq/what-best-practices-are-recommended-for-naming-metrics-and-tags/]
   * @param client
   */
-class DatadogRegistry()(implicit client: StatsDClient) extends HttpMetricsRegistry {
+class DatadogRegistry(settings: HttpMetricsSettings)(implicit client: StatsDClient)
+    extends HttpMetricsRegistry(settings) {
 
   override lazy val active: Gauge = new StatsDGauge("akka.http.requests_active")
 
@@ -47,4 +51,5 @@ class DatadogRegistry()(implicit client: StatsDClient) extends HttpMetricsRegist
   override lazy val connected: Gauge = new StatsDGauge("akka.http.connections_active")
 
   override lazy val connections: Counter = new StatsDCounter("akka.http.connections_count")
+
 }

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
@@ -19,73 +19,32 @@ package fr.davit.akka.http.metrics.datadog
 import com.timgroup.statsd.StatsDClient
 import fr.davit.akka.http.metrics.core._
 
-import scala.concurrent.duration.FiniteDuration
-
 object DatadogRegistry {
 
-  val AkkaPrefix = "akka.http"
-
-  def name(names: String*): String = s"$AkkaPrefix.${names.mkString("_")}"
-
-  def dimensionToTag(dimension: Dimension): String = s"${dimension.key}:${dimension.value}"
-
-  private implicit class RichStatsDClient(client: StatsDClient) {
-
-    def longCounter(name: String): Counter[Long] = new Counter[Long] {
-      override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        client.increment(name, dimensions.map(dimensionToTag): _*)
-      }
-    }
-
-    def longGauge(name: String): Gauge[Long] = new Gauge[Long] {
-      override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        client.increment(name, dimensions.map(dimensionToTag): _*)
-      }
-
-      override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        client.decrement(name, dimensions.map(dimensionToTag): _*)
-      }
-    }
-
-    def timer(name: String): Timer = new Timer {
-      override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        client.distribution(name, duration.toMillis, dimensions.map(dimensionToTag): _*)
-      }
-    }
-
-    def longHistogram(name: String): Histogram[Long] = new Histogram[Long] {
-      override def update(value: Long, dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        client.distribution(name, value, dimensions.map(dimensionToTag): _*)
-      }
-    }
-  }
-
-  def apply(client: StatsDClient): DatadogRegistry = new DatadogRegistry(client)
+  def apply(client: StatsDClient): DatadogRegistry = new DatadogRegistry()(client)
 }
 
 /**
   * see [https://docs.datadoghq.com/developers/faq/what-best-practices-are-recommended-for-naming-metrics-and-tags/]
   * @param client
   */
-class DatadogRegistry(client: StatsDClient) extends HttpMetricsRegistry {
+class DatadogRegistry()(implicit client: StatsDClient) extends HttpMetricsRegistry {
 
-  import DatadogRegistry._
+  override lazy val active: Gauge = new StatsDGauge("akka.http.requests_active")
 
-  override val active: Gauge[Long] = client.longGauge(name("requests", "active"))
+  override lazy val requests: Counter = new StatsDCounter("akka.http.requests_count")
 
-  override val requests: Counter[Long] = client.longCounter(name("requests", "count"))
+  override lazy val receivedBytes: Histogram = new StatsDHistogram("akka.http.requests_bytes")
 
-  override val receivedBytes: Histogram[Long] = client.longHistogram(name("requests", "bytes"))
+  override lazy val responses: Counter = new StatsDCounter("akka.http.responses_count")
 
-  override val responses: Counter[Long] = client.longCounter(name("responses", "count"))
+  override lazy val errors: Counter = new StatsDCounter("akka.http.responses_errors_count")
 
-  override val errors: Counter[Long] = client.longCounter(name("responses", "errors", "count"))
+  override lazy val duration: Timer = new StatsDTimer("akka.http.responses_duration")
 
-  override val duration: Timer = client.timer(name("responses", "duration"))
+  override lazy val sentBytes: Histogram = new StatsDHistogram("akka.http.responses_bytes")
 
-  override val sentBytes: Histogram[Long] = client.longHistogram(name("responses", "bytes"))
+  override lazy val connected: Gauge = new StatsDGauge("akka.http.connections_active")
 
-  override val connected: Gauge[Long] = client.longGauge(name("connections", "active"))
-
-  override val connections: Counter[Long] = client.longCounter(name("connections", "count"))
+  override lazy val connections: Counter = new StatsDCounter("akka.http.connections_count")
 }

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/StatsDMetrics.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/StatsDMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.datadog
 
 import com.timgroup.statsd.StatsDClient

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/StatsDMetrics.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/StatsDMetrics.scala
@@ -1,0 +1,38 @@
+package fr.davit.akka.http.metrics.datadog
+
+import com.timgroup.statsd.StatsDClient
+import fr.davit.akka.http.metrics.core.{Counter, Dimension, Gauge, Histogram, Timer}
+
+import scala.concurrent.duration.FiniteDuration
+
+object StatsDMetrics {
+  def dimensionToTag(dimension: Dimension): String = s"${dimension.key}:${dimension.value}"
+}
+
+class StatsDCounter(name: String)(implicit client: StatsDClient) extends Counter {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.increment(name, dimensions.map(StatsDMetrics.dimensionToTag): _*)
+  }
+}
+
+class StatsDGauge(name: String)(implicit client: StatsDClient) extends Gauge {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.increment(name, dimensions.map(StatsDMetrics.dimensionToTag): _*)
+  }
+
+  override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.decrement(name, dimensions.map(StatsDMetrics.dimensionToTag): _*)
+  }
+}
+
+class StatsDTimer(name: String)(implicit client: StatsDClient) extends Timer {
+  override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.distribution(name, duration.toMillis, dimensions.map(StatsDMetrics.dimensionToTag): _*)
+  }
+}
+
+class StatsDHistogram(name: String)(implicit client: StatsDClient) extends Histogram {
+  override def update[T](value: T, dimensions: Seq[Dimension] = Seq.empty)(implicit numeric: Numeric[T]): Unit = {
+    client.distribution(name, numeric.toDouble(value), dimensions.map(StatsDMetrics.dimensionToTag): _*)
+  }
+}

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardMetrics.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.dropwizard
 
 import fr.davit.akka.http.metrics.core.{Counter, Dimension, Gauge, Histogram, Timer}

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardMetrics.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardMetrics.scala
@@ -1,0 +1,41 @@
+package fr.davit.akka.http.metrics.dropwizard
+
+import fr.davit.akka.http.metrics.core.{Counter, Dimension, Gauge, Histogram, Timer}
+import io.dropwizard.metrics5.{MetricName, MetricRegistry}
+
+import scala.concurrent.duration.FiniteDuration
+
+object DropwizardMetrics {
+
+  def name(name: String, dimensions: Seq[Dimension]): MetricName = {
+    MetricName.build(name).tagged(dimensions.flatMap(d => Seq(d.key, d.value)): _*)
+  }
+}
+
+class DropwizardCounter(name: String)(implicit registry: MetricRegistry) extends Counter {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    registry.counter(DropwizardMetrics.name(name, dimensions)).inc()
+  }
+}
+
+class DropwizardGauge(name: String)(implicit registry: MetricRegistry) extends Gauge {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    registry.counter(DropwizardMetrics.name(name, dimensions)).inc()
+  }
+
+  override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    registry.counter(DropwizardMetrics.name(name, dimensions)).dec()
+  }
+}
+
+class DropwizardTimer(name: String)(implicit registry: MetricRegistry) extends Timer {
+  override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    registry.timer(DropwizardMetrics.name(name, dimensions)).update(duration.length, duration.unit)
+  }
+}
+
+class DropwizardHistogram(name: String)(implicit registry: MetricRegistry) extends Histogram {
+  override def update[T](value: T, dimensions: Seq[Dimension] = Seq.empty)(implicit numeric: Numeric[T]): Unit = {
+    registry.histogram(DropwizardMetrics.name(name, dimensions)).update(numeric.toLong(value))
+  }
+}

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
@@ -17,73 +17,32 @@
 package fr.davit.akka.http.metrics.dropwizard
 
 import fr.davit.akka.http.metrics.core._
-import io.dropwizard.metrics5.{MetricName, MetricRegistry}
-
-import scala.concurrent.duration.FiniteDuration
+import io.dropwizard.metrics5.MetricRegistry
 
 object DropwizardRegistry {
 
-  private val AkkaPrefix = Seq("akka", "http")
-
-  private implicit class RichMetricsRegistry(underlying: MetricRegistry) {
-
-    private def metricName(name: Seq[String], dimensions: Seq[Dimension]): MetricName = {
-      MetricName.build(AkkaPrefix ++ name: _*).tagged(dimensions.flatMap(d => Seq(d.key, d.value)): _*)
-    }
-
-    def longCounter(name: String*): Counter[Long] = new Counter[Long] {
-      override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        underlying.counter(metricName(name, dimensions)).inc()
-      }
-    }
-
-    def longGauge(name: String*): Gauge[Long] = new Gauge[Long] {
-      override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        underlying.counter(metricName(name, dimensions)).inc()
-      }
-
-      override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        underlying.counter(metricName(name, dimensions)).dec()
-      }
-    }
-
-    def customTimer(name: String*): Timer = new Timer {
-      override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        underlying.timer(metricName(name, dimensions)).update(duration.length, duration.unit)
-      }
-    }
-
-    def longHistogram(name: String*): Histogram[Long] = new Histogram[Long] {
-      override def update(value: Long, dimensions: Seq[Dimension] = Seq.empty): Unit = {
-        underlying.histogram(metricName(name, dimensions)).update(value)
-      }
-    }
-  }
-
   def apply(registry: MetricRegistry = new MetricRegistry()): DropwizardRegistry = {
-    new DropwizardRegistry(registry)
+    new DropwizardRegistry()(registry)
   }
 }
 
-class DropwizardRegistry(val underlying: MetricRegistry) extends HttpMetricsRegistry {
+class DropwizardRegistry()(implicit val underlying: MetricRegistry) extends HttpMetricsRegistry {
 
-  import DropwizardRegistry._
+  override lazy val active: Gauge = new DropwizardGauge("akka.http.requests.active")
 
-  override val active: Gauge[Long] = underlying.longGauge("requests", "active")
+  override lazy val requests: Counter = new DropwizardCounter("akka.http.requests")
 
-  override val requests: Counter[Long] = underlying.longCounter("requests")
+  override lazy val receivedBytes: Histogram = new DropwizardHistogram("akka.http.requests.bytes")
 
-  override val receivedBytes: Histogram[Long] = underlying.longHistogram("requests", "bytes")
+  override lazy val responses: Counter = new DropwizardCounter("akka.http.responses")
 
-  override val responses: Counter[Long] = underlying.longCounter("responses")
+  override lazy val errors: Counter = new DropwizardCounter("akka.http.responses.errors")
 
-  override val errors: Counter[Long] = underlying.longCounter("responses", "errors")
+  override lazy val duration: Timer = new DropwizardTimer("akka.http.responses.duration")
 
-  override val duration: Timer = underlying.customTimer("responses", "duration")
+  override lazy val sentBytes: Histogram = new DropwizardHistogram("akka.http.responses.bytes")
 
-  override val sentBytes: Histogram[Long] = underlying.longHistogram("responses", "bytes")
+  override lazy val connected: Gauge = new DropwizardGauge("akka.http.connections.active")
 
-  override val connected: Gauge[Long] = underlying.longGauge("connections", "active")
-
-  override val connections: Counter[Long] = underlying.longCounter("connections")
+  override lazy val connections: Counter = new DropwizardCounter("akka.http.connections")
 }

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
@@ -17,16 +17,21 @@
 package fr.davit.akka.http.metrics.dropwizard
 
 import fr.davit.akka.http.metrics.core._
+import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsSettings
 import io.dropwizard.metrics5.MetricRegistry
 
 object DropwizardRegistry {
 
-  def apply(registry: MetricRegistry = new MetricRegistry()): DropwizardRegistry = {
-    new DropwizardRegistry()(registry)
+  def apply(
+      registry: MetricRegistry = new MetricRegistry(),
+      settings: HttpMetricsSettings = HttpMetricsSettings.default
+  ): DropwizardRegistry = {
+    new DropwizardRegistry(settings)(registry)
   }
 }
 
-class DropwizardRegistry()(implicit val underlying: MetricRegistry) extends HttpMetricsRegistry {
+class DropwizardRegistry(settings: HttpMetricsSettings)(implicit val underlying: MetricRegistry)
+    extends HttpMetricsRegistry(settings) {
 
   override lazy val active: Gauge = new DropwizardGauge("akka.http.requests.active")
 

--- a/dropwizard/src/test/scala/fr/davit/akka/http/metrics/dropwizard/marshalling/DropwizardMarshallersSpec.scala
+++ b/dropwizard/src/test/scala/fr/davit/akka/http/metrics/dropwizard/marshalling/DropwizardMarshallersSpec.scala
@@ -68,7 +68,7 @@ class DropwizardMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
         "akka.http.responses.duration{status=2xx}",
         "akka.http.responses.bytes",
         "other.metric"
-      )
+      ).toSet
     }
   }
 

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/CarbonMetrics.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/CarbonMetrics.scala
@@ -1,0 +1,41 @@
+package fr.davit.akka.http.metrics.graphite
+
+import fr.davit.akka.http.metrics.core.{Counter, Dimension, Gauge, Histogram, Timer}
+
+import scala.concurrent.duration.FiniteDuration
+
+object CarbonMetrics {
+
+  def name(name: String, dimensions: Seq[Dimension]): String = {
+    val tags = dimensions.map(d => d.key + "=" + d.value).toList
+    (name :: tags).mkString(";")
+  }
+}
+
+class CarbonCounter(name: String)(implicit client: CarbonClient) extends Counter {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.publish(CarbonMetrics.name(name, dimensions), 1)
+  }
+}
+
+class CarbonGauge(name: String)(implicit client: CarbonClient) extends Gauge {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.publish(CarbonMetrics.name(name, dimensions), 1)
+  }
+
+  override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.publish(CarbonMetrics.name(name, dimensions), -1)
+  }
+}
+
+class CarbonTimer(name: String)(implicit client: CarbonClient) extends Timer {
+  override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.publish(CarbonMetrics.name(name, dimensions), duration.toMillis)
+  }
+}
+
+class CarbonHistogram(name: String)(implicit client: CarbonClient) extends Histogram {
+  override def update[T: Numeric](value: T, dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    client.publish(CarbonMetrics.name(name, dimensions), value)
+  }
+}

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/CarbonMetrics.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/CarbonMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.graphite
 
 import fr.davit.akka.http.metrics.core.{Counter, Dimension, Gauge, Histogram, Timer}

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteRegistry.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteRegistry.scala
@@ -17,12 +17,17 @@
 package fr.davit.akka.http.metrics.graphite
 
 import fr.davit.akka.http.metrics.core._
+import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsSettings
 
 object GraphiteRegistry {
-  def apply(client: CarbonClient): GraphiteRegistry = new GraphiteRegistry()(client)
+
+  def apply(client: CarbonClient, settings: HttpMetricsSettings = HttpMetricsSettings.default): GraphiteRegistry = {
+    new GraphiteRegistry(settings)(client)
+  }
 }
 
-class GraphiteRegistry()(implicit client: CarbonClient) extends HttpMetricsRegistry {
+class GraphiteRegistry(settings: HttpMetricsSettings)(implicit client: CarbonClient)
+    extends HttpMetricsRegistry(settings) {
 
   override lazy val active: Gauge = new CarbonGauge("akka.http.requests.active")
 

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusConverters.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusConverters.scala
@@ -1,0 +1,18 @@
+package fr.davit.akka.http.metrics.prometheus
+
+trait PrometheusConverters {
+
+  implicit def convertCounter(counter: io.prometheus.client.Counter): PrometheusCounter = new PrometheusCounter(counter)
+
+  implicit def convertGauge(gauge: io.prometheus.client.Gauge): PrometheusGauge = new PrometheusGauge(gauge)
+
+  implicit def convertTimer(summary: io.prometheus.client.Summary): PrometheusTimer = new PrometheusTimer(summary)
+
+  implicit def convertSummary(summary: io.prometheus.client.Summary): PrometheusSummary = new PrometheusSummary(summary)
+
+  implicit def convertHistogram(histogram: io.prometheus.client.Histogram): PrometheusHistogram =
+    new PrometheusHistogram(histogram)
+
+}
+
+object PrometheusConverters extends PrometheusConverters

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusConverters.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusConverters.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.prometheus
 
 trait PrometheusConverters {

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusMetrics.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusMetrics.scala
@@ -1,0 +1,39 @@
+package fr.davit.akka.http.metrics.prometheus
+
+import fr.davit.akka.http.metrics.core._
+
+import scala.concurrent.duration.FiniteDuration
+
+class PrometheusCounter(counter: io.prometheus.client.Counter) extends Counter {
+  override def inc(dimensions: Seq[Dimension]): Unit = {
+    counter.labels(dimensions.map(_.value): _*).inc()
+  }
+}
+
+class PrometheusGauge(gauge: io.prometheus.client.Gauge) extends Gauge {
+  override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    gauge.labels(dimensions.map(_.value): _*).inc()
+  }
+
+  override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    gauge.labels(dimensions.map(_.value): _*).dec()
+  }
+}
+
+class PrometheusTimer(summary: io.prometheus.client.Summary) extends Timer {
+  override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
+    summary.labels(dimensions.map(_.value): _*).observe(duration.toMillis.toDouble / 1000.0)
+  }
+}
+
+class PrometheusSummary(summary: io.prometheus.client.Summary) extends Histogram {
+  override def update[T](value: T, dimensions: Seq[Dimension] = Seq.empty)(implicit numeric: Numeric[T]): Unit = {
+    summary.labels(dimensions.map(_.value): _*).observe(numeric.toDouble(value))
+  }
+}
+
+class PrometheusHistogram(histogram: io.prometheus.client.Histogram) extends Histogram {
+  override def update[T](value: T, dimensions: Seq[Dimension] = Seq.empty)(implicit numeric: Numeric[T]): Unit = {
+    histogram.labels(dimensions.map(_.value): _*).observe(numeric.toDouble(value))
+  }
+}

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusMetrics.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.prometheus
 
 import fr.davit.akka.http.metrics.core._

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -25,8 +25,8 @@ object PrometheusRegistry {
   private val Tolerance = 0.05
 
   def apply(
-      settings: HttpMetricsSettings,
-      underlying: CollectorRegistry = CollectorRegistry.defaultRegistry
+      underlying: CollectorRegistry = CollectorRegistry.defaultRegistry,
+      settings: HttpMetricsSettings = HttpMetricsSettings.default
   ): PrometheusRegistry = {
     new PrometheusRegistry(settings, underlying)
   }
@@ -36,7 +36,8 @@ object PrometheusRegistry {
   * Prometheus registry
   * For metrics naming see [https://prometheus.io/docs/practices/naming/]
   */
-class PrometheusRegistry(settings: HttpMetricsSettings, val underlying: CollectorRegistry) extends HttpMetricsRegistry {
+class PrometheusRegistry(settings: HttpMetricsSettings, val underlying: CollectorRegistry)
+    extends HttpMetricsRegistry(settings) {
 
   import PrometheusRegistry._
   import PrometheusConverters._

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -20,43 +20,9 @@ import fr.davit.akka.http.metrics.core._
 import fr.davit.akka.http.metrics.core.scaladsl.server.HttpMetricsSettings
 import io.prometheus.client.CollectorRegistry
 
-import scala.concurrent.duration.FiniteDuration
-
 object PrometheusRegistry {
 
-  private val AkkaPrefix = "akka_http"
-
   private val Tolerance = 0.05
-
-  private def name(names: String*): String = (AkkaPrefix +: names).mkString("_")
-
-  private implicit def toLongCounter(counter: io.prometheus.client.Counter): Counter[Long] = new Counter[Long] {
-    override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-      counter.labels(dimensions.map(_.value): _*).inc()
-    }
-  }
-
-  private implicit def toLongGauge(gauge: io.prometheus.client.Gauge): Gauge[Long] = new Gauge[Long] {
-    override def inc(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-      gauge.labels(dimensions.map(_.value): _*).inc()
-    }
-
-    override def dec(dimensions: Seq[Dimension] = Seq.empty): Unit = {
-      gauge.labels(dimensions.map(_.value): _*).dec()
-    }
-  }
-
-  private implicit def toTimer(summary: io.prometheus.client.Summary): Timer = new Timer {
-    override def observe(duration: FiniteDuration, dimensions: Seq[Dimension] = Seq.empty): Unit = {
-      summary.labels(dimensions.map(_.value): _*).observe(duration.toMillis.toDouble / 1000.0)
-    }
-  }
-
-  private implicit def toLongHistogram(summary: io.prometheus.client.Summary): Histogram[Long] = new Histogram[Long] {
-    override def update(value: Long, dimensions: Seq[Dimension] = Seq.empty): Unit = {
-      summary.labels(dimensions.map(_.value): _*).observe(value.toDouble)
-    }
-  }
 
   def apply(
       settings: HttpMetricsSettings,
@@ -73,6 +39,7 @@ object PrometheusRegistry {
 class PrometheusRegistry(settings: HttpMetricsSettings, val underlying: CollectorRegistry) extends HttpMetricsRegistry {
 
   import PrometheusRegistry._
+  import PrometheusConverters._
 
   private val labels: Seq[String] = {
     val statusLabel = if (settings.includeStatusDimension) Some("status") else None
@@ -81,16 +48,16 @@ class PrometheusRegistry(settings: HttpMetricsSettings, val underlying: Collecto
     statusLabel.toSeq ++ pathLabel
   }
 
-  override val active: Gauge[Long] = io.prometheus.client.Gauge
-    .build(name("requests", "active"), "Active HTTP requests")
+  override lazy val active: Gauge = io.prometheus.client.Gauge
+    .build("akka_http_requests_active", "Active HTTP requests")
     .register(underlying)
 
-  override val requests: Counter[Long] = io.prometheus.client.Counter
-    .build(name("requests", "total"), "Total HTTP requests")
+  override lazy val requests: Counter = io.prometheus.client.Counter
+    .build("akka_http_requests_total", "Total HTTP requests")
     .register(underlying)
 
-  override val receivedBytes: Histogram[Long] = io.prometheus.client.Summary
-    .build(name("requests", "size", "bytes"), "HTTP request size")
+  override lazy val receivedBytes: Histogram = io.prometheus.client.Summary
+    .build("akka_http_requests_size_bytes", "HTTP request size")
     .quantile(0.75, Tolerance)
     .quantile(0.95, Tolerance)
     .quantile(0.98, Tolerance)
@@ -98,28 +65,18 @@ class PrometheusRegistry(settings: HttpMetricsSettings, val underlying: Collecto
     .quantile(0.999, Tolerance)
     .register(underlying)
 
-  override val responses: Counter[Long] = io.prometheus.client.Counter
-    .build(name("responses", "total"), "HTTP responses")
+  override lazy val responses: Counter = io.prometheus.client.Counter
+    .build("akka_http_responses_total", "HTTP responses")
     .labelNames(labels: _*)
     .register(underlying)
 
-  override val errors: Counter[Long] = io.prometheus.client.Counter
-    .build(name("responses", "errors", "total"), "Total HTTP errors")
+  override lazy val errors: Counter = io.prometheus.client.Counter
+    .build("akka_http_responses_errors_total", "Total HTTP errors")
     .labelNames(labels: _*)
     .register(underlying)
 
-  override val duration: Timer = io.prometheus.client.Summary
-    .build(name("responses", "duration", "seconds"), "HTTP response duration")
-    .labelNames(labels: _*)
-    .quantile(0.75, Tolerance)
-    .quantile(0.95, Tolerance)
-    .quantile(0.98, Tolerance)
-    .quantile(0.99, Tolerance)
-    .quantile(0.999, Tolerance)
-    .register(underlying)
-
-  override val sentBytes: Histogram[Long] = io.prometheus.client.Summary
-    .build(name("responses", "size", "bytes"), "HTTP response size")
+  override lazy val duration: Timer = io.prometheus.client.Summary
+    .build("akka_http_responses_duration_seconds", "HTTP response duration")
     .labelNames(labels: _*)
     .quantile(0.75, Tolerance)
     .quantile(0.95, Tolerance)
@@ -128,11 +85,21 @@ class PrometheusRegistry(settings: HttpMetricsSettings, val underlying: Collecto
     .quantile(0.999, Tolerance)
     .register(underlying)
 
-  override val connected: Gauge[Long] = io.prometheus.client.Gauge
-    .build(name("connections", "active"), "Active TCP connections")
+  override lazy val sentBytes: Histogram = io.prometheus.client.Summary
+    .build("akka_http_responses_size_bytes", "HTTP response size")
+    .labelNames(labels: _*)
+    .quantile(0.75, Tolerance)
+    .quantile(0.95, Tolerance)
+    .quantile(0.98, Tolerance)
+    .quantile(0.99, Tolerance)
+    .quantile(0.999, Tolerance)
     .register(underlying)
 
-  override val connections: Counter[Long] = io.prometheus.client.Counter
-    .build(name("connections", "total"), "Total TCP connections")
+  override val connected: Gauge = io.prometheus.client.Gauge
+    .build("akka_http_connections_active", "Active TCP connections")
+    .register(underlying)
+
+  override val connections: Counter = io.prometheus.client.Counter
+    .build("akka_http_connections_total", "Total TCP connections")
     .register(underlying)
 }

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -31,7 +31,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
   val dimensions = Seq(StatusGroupDimension(StatusCodes.OK), PathDimension("/api"))
 
   trait Fixture {
-    val registry = PrometheusRegistry(HttpMetricsSettings.default, new CollectorRegistry())
+    val registry = PrometheusRegistry(new CollectorRegistry())
 
     def underlyingCounterValue(name: String, dims: Seq[Dimension] = Seq.empty): Long = {
       registry.underlying.getSampleValue(name, dims.map(_.key).toArray, dims.map(_.value).toArray).toLong
@@ -44,8 +44,8 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   trait DimensionFixture extends Fixture {
     override val registry = PrometheusRegistry(
-      HttpMetricsSettings.default.withIncludeStatusDimension(true).withIncludePathDimension(true),
-      new CollectorRegistry()
+      new CollectorRegistry(),
+      HttpMetricsSettings.default.withIncludeStatusDimension(true).withIncludePathDimension(true)
     )
   }
 

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/marshalling/PrometheusMarshallersSpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/marshalling/PrometheusMarshallersSpec.scala
@@ -34,8 +34,8 @@ class PrometheusMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
   trait Fixture extends PrometheusMarshallers {
 
     val registry = PrometheusRegistry(
-      HttpMetricsSettings.default.withIncludeStatusDimension(true),
-      new CollectorRegistry()
+      new CollectorRegistry(),
+      HttpMetricsSettings.default.withIncludeStatusDimension(true)
     )
 
     io.prometheus.client.Counter


### PR DESCRIPTION
Changes towards v1:

- Decorrelate akka-http routes from registry
- Remove useless generic type parameter from model
- Add `HttpMetricsHandler` to give user more freedom on metrics implementation
- Let registry implementation be overridden

Fixes #25 