### PR TITLE
Add more context to enabling labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ By default metrics labels are disabled. You can enable them in the settings.
 val settings = HttpMetricsSettings.default
   .withIncludeStatusDimension(true)
   .withIncludePathDimension(true)
+
+Http().bindAndHandle(route.recordMetrics(registry, settings), "localhost", 8080)
 ```
 
 ##### Status group


### PR DESCRIPTION
It took me a while to realize I had to pass my custom settings into `recordMetrics`. I kept getting a "Incorrect number of labels" error, which led me down the rabbit hole for a couple hours. Thought this small addition would help a bit for the next person.