### PR TITLE
allow ability to specify metrics names in prometheus implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/
 .bloop/
 .metals/
+out/
 target/
 project/target/
 project/metals.sbt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update to akka-http 10.2
 - Update libraries
+- Add metrics names to settings
+- Streamline metrics, name and doc
 
 ## 1.1.1 (2020-06-10)
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ The library enables you to easily record the following metrics from an akka-http
 following labeled metrics are recorded:
 
 - requests (`counter`)
-- active requests (`gauge`)
-- request sizes (`histogram`)
+- requests active (`gauge`)
+- requests size (`histogram`)
 - responses (`counter`) [status group | path]
-- errors [status group | path]
-- durations (`histogram`) [status group | path]
-- response sizes (`histogram`) [status group | path]
+- responses errors [status group | path]
+- responses duration (`histogram`) [status group | path]
+- response size (`histogram`) [status group | path]
 - connections (`counter`)
-- active connections (`gauge`)
+- connections active (`gauge`)
 
 Record metrics from your akka server by importing the implicits from `HttpMetricsRoute`. Convert your route to the
 flow that will handle requests with `recordMetrics` and bind your server to the desired port.
@@ -165,14 +165,14 @@ Of course, you will also need to have the implicit marshaller for your registry 
 | metric             | name                   |
 |--------------------|------------------------|
 | requests           | requests_count         |
-| active requests    | requests_active        |
-| request sizes      | requests_bytes         |
+| requests active    | requests_active        |
+| requests size      | requests_bytes         |
 | responses          | responses_count        |
-| errors             | responses_errors_count |
-| durations          | responses_duration     |
-| response sizes     | response_bytes         |
+| responses errors   | responses_errors_count |
+| responses duration | responses_duration     |
+| responses size     | responses_bytes         |
 | connections        | connections_count      |
-| active connections | connections_active     |
+| connections active | connections_active     |
 
 The `DatadogRegistry` is just a facade to publish to your StatsD server. The registry itself not located in the JVM, 
 for this reason it is not possible to expose the metrics in your API.
@@ -202,14 +202,14 @@ See datadog's [documentation](https://github.com/dataDog/java-dogstatsd-client) 
 | metric             | name               |
 |--------------------|--------------------|
 | requests           | requests           |
-| active requests    | requests.active    |
-| request sizes      | requests.bytes     |
+| requests active    | requests.active    |
+| requests size      | requests.bytes     |
 | responses          | responses          |
-| errors             | responses.errors   |
-| durations          | responses.duration |
-| response sizes     | responses.bytes    |
+| responses errors   | responses.errors   |
+| responses duration | responses.duration |
+| responses size     | responses.bytes    |
 | connections        | connections        |
-| active connections | connections.active |
+| connections active | connections.active |
 
 **Important**: The `DropwizardRegistry` works with tags. This feature is only supported since dropwizard `v5`. 
 
@@ -243,14 +243,14 @@ val route = (get & path("metrics"))(metrics(registry))
 | metric             | name               |
 |--------------------|--------------------|
 | requests           | requests           |
-| active requests    | requests.active    |
-| request sizes      | requests.bytes     |
+| requests active    | requests.active    |
+| requests size      | requests.bytes     |
 | responses          | responses          |
-| errors             | responses.errors   |
-| durations          | responses.duration |
-| response sizes     | responses.bytes    |
+| responses errors   | responses.errors   |
+| responses duration | responses.duration |
+| response size      | responses.bytes    |
 | connections        | connections        |
-| active connections | connections.active |
+| connections active | connections.active |
 
 Add to your `build.sbt`:
 
@@ -273,14 +273,14 @@ val registry = GraphiteRegistry(carbonClient)
 | metric             | name                       |
 |--------------------|----------------------------|
 | requests           | requests_total             |
-| active requests    | requests_active            |
-| request sizes      | requests_size_bytes        |
+| requests active    | requests_active            |
+| requests size      | requests_size_bytes        |
 | responses          | responses_total            |
-| errors             | responses_errors_total     |
-| durations          | responses_duration_seconds |
-| response sizes     | responses_size_bytes       |
+| responses errors   | responses_errors_total     |
+| responses duration | responses_duration_seconds |
+| responses size     | responses_size_bytes       |
 | connections        | connections_total          |
-| active connections | connections_active         |
+| connections active | connections_active         |
 
 Add to your `build.sbt`:
 
@@ -301,7 +301,7 @@ val registry = PrometheusRegistry(prometheus, settings) // or PrometheusRegistry
 ```
 
 You can fine-tune the `histogram/summary` configuration of `buckets/quantiles` for the `request
- sizes`, `durations` and `response sizes` metrics.
+ size`, `duration` and `response size` metrics.
  
 ```scala
 val settings: PrometheusSettings = PrometheusSettings

--- a/core/src/it/scala/fr/davit/akka/http/metrics/core/HttpMetricsItSpec.scala
+++ b/core/src/it/scala/fr/davit/akka/http/metrics/core/HttpMetricsItSpec.scala
@@ -45,7 +45,7 @@ class HttpMetricsItSpec
   }
 
   trait Fixture {
-    val settings: HttpMetricsSettings = HttpMetricsSettings.default
+    val settings: HttpMetricsSettings = TestRegistry.settings
       .withNamespace("com.example.service")
 
     val registry = new TestRegistry(settings)

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsNames.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsNames.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.davit.akka.http.metrics.core
+
+case class HttpMetricsNames(
+    requests: String,
+    activeRequests: String,
+    requestSizes: String,
+    responses: String,
+    errors: String,
+    durations: String,
+    responseSizes: String,
+    connections: String,
+    activeConnections: String
+) {
+
+  def withRequests(name: String): HttpMetricsNames =
+    copy(requests = name)
+
+  def withActiveRequests(name: String): HttpMetricsNames =
+    copy(activeRequests = name)
+
+  def withRequestSizes(name: String): HttpMetricsNames =
+    copy(requestSizes = name)
+
+  def withResponses(name: String): HttpMetricsNames =
+    copy(responses = name)
+
+  def withErrors(name: String): HttpMetricsNames =
+    copy(errors = name)
+
+  def withDurations(name: String): HttpMetricsNames =
+    copy(durations = name)
+
+  def withResponseSizes(name: String): HttpMetricsNames =
+    copy(responseSizes = name)
+
+  def withConnections(name: String): HttpMetricsNames =
+    copy(connections = name)
+
+  def withActiveConnections(name: String): HttpMetricsNames =
+    copy(activeConnections = name)
+}

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsNames.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsNames.scala
@@ -16,42 +16,51 @@
 
 package fr.davit.akka.http.metrics.core
 
-case class HttpMetricsNames(
-    requests: String,
-    activeRequests: String,
-    requestSizes: String,
-    responses: String,
-    errors: String,
-    durations: String,
-    responseSizes: String,
-    connections: String,
-    activeConnections: String
-) {
+trait HttpMetricsNames {
+  def requests: String
+  def activeRequests: String
+  def requestSizes: String
+  def responses: String
+  def errors: String
+  def durations: String
+  def responseSizes: String
+  def connections: String
+  def activeConnections: String
 
-  def withRequests(name: String): HttpMetricsNames =
-    copy(requests = name)
+  def withRequests(name: String): HttpMetricsNames
+  def withActiveRequests(name: String): HttpMetricsNames
+  def withRequestSizes(name: String): HttpMetricsNames
+  def withResponses(name: String): HttpMetricsNames
+  def withErrors(name: String): HttpMetricsNames
+  def withDurations(name: String): HttpMetricsNames
+  def withResponseSizes(name: String): HttpMetricsNames
+  def withConnections(name: String): HttpMetricsNames
+  def withActiveConnections(name: String): HttpMetricsNames
 
-  def withActiveRequests(name: String): HttpMetricsNames =
-    copy(activeRequests = name)
+}
 
-  def withRequestSizes(name: String): HttpMetricsNames =
-    copy(requestSizes = name)
+object HttpMetricsNames {
 
-  def withResponses(name: String): HttpMetricsNames =
-    copy(responses = name)
+  private[metrics] case class HttpMetricsNamesImpl(
+      requests: String,
+      activeRequests: String,
+      requestSizes: String,
+      responses: String,
+      errors: String,
+      durations: String,
+      responseSizes: String,
+      connections: String,
+      activeConnections: String
+  ) extends HttpMetricsNames {
+    def withRequests(name: String): HttpMetricsNamesImpl          = copy(requests = name)
+    def withActiveRequests(name: String): HttpMetricsNamesImpl    = copy(activeRequests = name)
+    def withRequestSizes(name: String): HttpMetricsNamesImpl      = copy(requestSizes = name)
+    def withResponses(name: String): HttpMetricsNamesImpl         = copy(responses = name)
+    def withErrors(name: String): HttpMetricsNamesImpl            = copy(errors = name)
+    def withDurations(name: String): HttpMetricsNamesImpl         = copy(durations = name)
+    def withResponseSizes(name: String): HttpMetricsNamesImpl     = copy(responseSizes = name)
+    def withConnections(name: String): HttpMetricsNamesImpl       = copy(connections = name)
+    def withActiveConnections(name: String): HttpMetricsNamesImpl = copy(activeConnections = name)
+  }
 
-  def withErrors(name: String): HttpMetricsNames =
-    copy(errors = name)
-
-  def withDurations(name: String): HttpMetricsNames =
-    copy(durations = name)
-
-  def withResponseSizes(name: String): HttpMetricsNames =
-    copy(responseSizes = name)
-
-  def withConnections(name: String): HttpMetricsNames =
-    copy(connections = name)
-
-  def withActiveConnections(name: String): HttpMetricsNames =
-    copy(activeConnections = name)
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsNames.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsNames.scala
@@ -18,24 +18,24 @@ package fr.davit.akka.http.metrics.core
 
 trait HttpMetricsNames {
   def requests: String
-  def activeRequests: String
-  def requestSizes: String
+  def requestsActive: String
+  def requestsSize: String
   def responses: String
-  def errors: String
-  def durations: String
-  def responseSizes: String
+  def responsesErrors: String
+  def responsesDuration: String
+  def responsesSize: String
   def connections: String
-  def activeConnections: String
+  def connectionsActive: String
 
   def withRequests(name: String): HttpMetricsNames
-  def withActiveRequests(name: String): HttpMetricsNames
-  def withRequestSizes(name: String): HttpMetricsNames
+  def withRequestsActive(name: String): HttpMetricsNames
+  def withRequestSize(name: String): HttpMetricsNames
   def withResponses(name: String): HttpMetricsNames
-  def withErrors(name: String): HttpMetricsNames
-  def withDurations(name: String): HttpMetricsNames
-  def withResponseSizes(name: String): HttpMetricsNames
+  def withResponsesErrors(name: String): HttpMetricsNames
+  def withResponsesDuration(name: String): HttpMetricsNames
+  def withResponseSize(name: String): HttpMetricsNames
   def withConnections(name: String): HttpMetricsNames
-  def withActiveConnections(name: String): HttpMetricsNames
+  def withConnectionsActive(name: String): HttpMetricsNames
 
 }
 
@@ -43,24 +43,24 @@ object HttpMetricsNames {
 
   private[metrics] case class HttpMetricsNamesImpl(
       requests: String,
-      activeRequests: String,
-      requestSizes: String,
+      requestsActive: String,
+      requestsSize: String,
       responses: String,
-      errors: String,
-      durations: String,
-      responseSizes: String,
+      responsesErrors: String,
+      responsesDuration: String,
+      responsesSize: String,
       connections: String,
-      activeConnections: String
+      connectionsActive: String
   ) extends HttpMetricsNames {
     def withRequests(name: String): HttpMetricsNamesImpl          = copy(requests = name)
-    def withActiveRequests(name: String): HttpMetricsNamesImpl    = copy(activeRequests = name)
-    def withRequestSizes(name: String): HttpMetricsNamesImpl      = copy(requestSizes = name)
+    def withRequestsActive(name: String): HttpMetricsNamesImpl    = copy(requestsActive = name)
+    def withRequestSize(name: String): HttpMetricsNamesImpl       = copy(requestsSize = name)
     def withResponses(name: String): HttpMetricsNamesImpl         = copy(responses = name)
-    def withErrors(name: String): HttpMetricsNamesImpl            = copy(errors = name)
-    def withDurations(name: String): HttpMetricsNamesImpl         = copy(durations = name)
-    def withResponseSizes(name: String): HttpMetricsNamesImpl     = copy(responseSizes = name)
+    def withResponsesErrors(name: String): HttpMetricsNamesImpl   = copy(responsesErrors = name)
+    def withResponsesDuration(name: String): HttpMetricsNamesImpl = copy(responsesDuration = name)
+    def withResponseSize(name: String): HttpMetricsNamesImpl      = copy(responsesSize = name)
     def withConnections(name: String): HttpMetricsNamesImpl       = copy(connections = name)
-    def withActiveConnections(name: String): HttpMetricsNamesImpl = copy(activeConnections = name)
+    def withConnectionsActive(name: String): HttpMetricsNamesImpl = copy(connectionsActive = name)
   }
 
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
@@ -16,7 +16,7 @@
 
 package fr.davit.akka.http.metrics.core
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.HttpResponse
 
 trait HttpMetricsSettings {
 
@@ -24,6 +24,11 @@ trait HttpMetricsSettings {
     * Metrics namespace
     */
   def namespace: String
+
+  /**
+    * Name of the individual metrics
+    */
+  def metricsNames: HttpMetricsNames
 
   /**
     * Function that defines if the http response should be
@@ -47,6 +52,7 @@ trait HttpMetricsSettings {
   def includeStatusDimension: Boolean
 
   def withNamespace(namespace: String): HttpMetricsSettings
+  def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings
   def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings
   def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings
   def withIncludePathDimension(include: Boolean): HttpMetricsSettings
@@ -55,46 +61,37 @@ trait HttpMetricsSettings {
 
 object HttpMetricsSettings {
 
-  val default: HttpMetricsSettings = apply(
-    "akka.http",
-    _.status.isInstanceOf[StatusCodes.ServerError],
-    includeMethodDimension = false,
-    includePathDimension = false,
-    includeStatusDimension = false
-  )
-
   def apply(
       namespace: String,
+      metricsNames: HttpMetricsNames,
       defineError: HttpResponse => Boolean,
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
       includeStatusDimension: Boolean
   ): HttpMetricsSettings = HttpMetricsSettingsImpl(
     namespace,
+    metricsNames,
     defineError,
     includeMethodDimension,
     includePathDimension,
     includeStatusDimension
   )
 
-  private case class HttpMetricsSettingsImpl(
+  private[metrics] case class HttpMetricsSettingsImpl(
       namespace: String,
+      metricsNames: HttpMetricsNames,
       defineError: HttpResponse => Boolean,
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
       includeStatusDimension: Boolean
   ) extends HttpMetricsSettings {
 
-    override def withNamespace(namespace: String): HttpMetricsSettings =
-      copy(namespace = namespace)
-    override def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings =
-      copy(defineError = fn)
-    override def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings =
-      copy(includeMethodDimension = include)
-    override def withIncludePathDimension(include: Boolean): HttpMetricsSettings =
-      copy(includePathDimension = include)
-    override def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings =
-      copy(includeStatusDimension = include)
+    def withNamespace(namespace: String): HttpMetricsSettings                 = copy(namespace = namespace)
+    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings = copy(metricsNames = metricsNames)
+    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings     = copy(defineError = fn)
+    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings     = copy(includeMethodDimension = include)
+    def withIncludePathDimension(include: Boolean): HttpMetricsSettings       = copy(includePathDimension = include)
+    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings     = copy(includeStatusDimension = include)
 
   }
 }

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
@@ -44,47 +44,47 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   }
 
   it should "compute the number of errors" in new Fixture() {
-    registry.errors.value() shouldBe 0
+    registry.responsesErrors.value() shouldBe 0
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.OK)))
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.TemporaryRedirect)))
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.BadRequest)))
-    registry.errors.value() shouldBe 0
+    registry.responsesErrors.value() shouldBe 0
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse(StatusCodes.InternalServerError)))
-    registry.errors.value() shouldBe 1
+    registry.responsesErrors.value() shouldBe 1
   }
 
   it should "compute the number of active requests" in new Fixture() {
-    registry.active.value() shouldBe 0
+    registry.requestsActive.value() shouldBe 0
     val promise = Promise[HttpResponse]()
     registry.onRequest(HttpRequest(), promise.future)
     registry.onRequest(HttpRequest(), promise.future)
-    registry.active.value() shouldBe 2
+    registry.requestsActive.value() shouldBe 2
     promise.success(HttpResponse())
-    registry.active.value() shouldBe 0
+    registry.requestsActive.value() shouldBe 0
   }
 
   it should "compute the requests time" in new Fixture() {
     val promise  = Promise[HttpResponse]()
     val duration = 500.millis
-    registry.duration.values() shouldBe empty
+    registry.responsesDuration.values() shouldBe empty
     registry.onRequest(HttpRequest(), promise.future)
     Thread.sleep(duration.toMillis)
     promise.success(HttpResponse())
-    registry.duration.values().head should be > duration
+    registry.responsesDuration.values().head should be > duration
   }
 
   it should "compute the requests size" in new Fixture() {
     val data = "This is the request content"
-    registry.receivedBytes.values() shouldBe empty
+    registry.requestsSize.values() shouldBe empty
     registry.onRequest(HttpRequest(entity = data), Future.successful(HttpResponse()))
-    registry.receivedBytes.values().head shouldBe data.getBytes.length
+    registry.requestsSize.values().head shouldBe data.getBytes.length
   }
 
   it should "compute the response size" in new Fixture() {
     val data = "This is the response content"
-    registry.sentBytes.values() shouldBe empty
+    registry.responsesSize.values() shouldBe empty
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse(entity = data)))
-    registry.sentBytes.values().head shouldBe data.getBytes.length
+    registry.responsesSize.values().head shouldBe data.getBytes.length
   }
 
   it should "compute the number of connections" in new Fixture() {
@@ -96,13 +96,13 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   }
 
   it should "compute the number of active connections" in new Fixture() {
-    registry.connected.value() shouldBe 0
+    registry.connectionsActive.value() shouldBe 0
     val promise = Promise[Done]()
     registry.onConnection(promise.future)
     registry.onConnection(promise.future)
-    registry.connected.value() shouldBe 2
+    registry.connectionsActive.value() shouldBe 2
     promise.success(Done)
-    registry.connected.value() shouldBe 0
+    registry.connectionsActive.value() shouldBe 0
   }
 
   it should "add status code dimension when enabled" in new Fixture(

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
@@ -31,7 +31,7 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
 
   implicit val currentThreadExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(_.run())
 
-  abstract class Fixture(settings: HttpMetricsSettings = HttpMetricsSettings.default) {
+  abstract class Fixture(settings: HttpMetricsSettings = TestRegistry.settings) {
     val registry = new TestRegistry(settings)
   }
 
@@ -106,7 +106,7 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   }
 
   it should "add status code dimension when enabled" in new Fixture(
-    HttpMetricsSettings.default.withIncludeStatusDimension(true)
+    TestRegistry.settings.withIncludeStatusDimension(true)
   ) {
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse()))
     registry.responses.value(Seq(StatusGroupDimension(StatusCodes.OK))) shouldBe 1
@@ -116,7 +116,7 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   }
 
   it should "add method dimension when enabled" in new Fixture(
-    HttpMetricsSettings.default.withIncludeMethodDimension(true)
+    TestRegistry.settings.withIncludeMethodDimension(true)
   ) {
     registry.onRequest(HttpRequest(), Future.successful(HttpResponse()))
     registry.responses.value(Seq(MethodDimension(HttpMethods.GET))) shouldBe 1
@@ -124,7 +124,7 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   }
 
   it should "default label dimension to 'unlabelled' when enabled but not annotated by directives" in new Fixture(
-    HttpMetricsSettings.default.withIncludePathDimension(true)
+    TestRegistry.settings.withIncludePathDimension(true)
   ) {
     registry.onRequest(HttpRequest().withUri("/unlabelled/path"), Future.successful(HttpResponse()))
     registry.responses.value(Seq(PathDimension("unlabelled"))) shouldBe 1
@@ -132,7 +132,7 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   }
 
   it should "increment proper label dimension" in new Fixture(
-    HttpMetricsSettings.default.withIncludePathDimension(true)
+    TestRegistry.settings.withIncludePathDimension(true)
   ) {
     val label = "/api"
     registry.onRequest(

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsSpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsSpec.scala
@@ -41,7 +41,7 @@ class HttpMetricsSpec
     """
       |import akka.http.scaladsl.Http
       |import fr.davit.akka.http.metrics.core.HttpMetrics._
-      |val registry = new TestRegistry(HttpMetricsSettings.default)
+      |val registry = new TestRegistry(TestRegistry.settings)
       |implicit val system: ActorSystem = ActorSystem()
       |Http().newMeteredServerAt("localhost", 8080, registry)
     """.stripMargin should compile

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
@@ -97,13 +97,13 @@ final class TestRegistry(settings: HttpMetricsSettings = TestRegistry.settings) 
 
   import TestRegistry._
 
-  override val active        = new TestGauge
-  override val requests      = new TestCounter
-  override val receivedBytes = new TestHistogram
-  override val responses     = new TestCounter
-  override val errors        = new TestCounter
-  override val duration      = new TestTimer
-  override val sentBytes     = new TestHistogram
-  override val connected     = new TestGauge
-  override val connections   = new TestCounter
+  override val requests          = new TestCounter
+  override val requestsActive    = new TestGauge
+  override val requestsSize      = new TestHistogram
+  override val responses         = new TestCounter
+  override val responsesErrors   = new TestCounter
+  override val responsesDuration = new TestTimer
+  override val responsesSize     = new TestHistogram
+  override val connections       = new TestCounter
+  override val connectionsActive = new TestGauge
 }

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/TestRegistry.scala
@@ -17,12 +17,24 @@
 package fr.davit.akka.http.metrics.core
 
 import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
-import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
+import fr.davit.akka.http.metrics.core.HttpMetricsSettings.HttpMetricsSettingsImpl
 
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
 object TestRegistry {
+
+  val settings: HttpMetricsSettings = HttpMetricsSettingsImpl(
+    "", // not used
+    HttpMetricsNamesImpl("", "", "", "", "", "", "", "", ""), // not used
+    _.status.isInstanceOf[StatusCodes.ServerError],
+    includeMethodDimension = false,
+    includePathDimension = false,
+    includeStatusDimension = false
+  )
+
   implicit val marshaller: ToEntityMarshaller[TestRegistry] = Marshaller.opaque(_ => HttpEntity.Empty)
 
   private def keyer(dimensions: Seq[Dimension]): String = dimensions.mkString(":")
@@ -81,26 +93,17 @@ object TestRegistry {
 
 }
 
-final class TestRegistry(settings: HttpMetricsSettings = HttpMetricsSettings.default)
-    extends HttpMetricsRegistry(settings) {
+final class TestRegistry(settings: HttpMetricsSettings = TestRegistry.settings) extends HttpMetricsRegistry(settings) {
 
   import TestRegistry._
 
-  override val active = new TestGauge
-
-  override val requests = new TestCounter
-
+  override val active        = new TestGauge
+  override val requests      = new TestCounter
   override val receivedBytes = new TestHistogram
-
-  override val responses = new TestCounter
-
-  override val errors = new TestCounter
-
-  override val duration = new TestTimer
-
-  override val sentBytes = new TestHistogram
-
-  override val connected = new TestGauge
-
-  override val connections = new TestCounter
+  override val responses     = new TestCounter
+  override val errors        = new TestCounter
+  override val duration      = new TestTimer
+  override val sentBytes     = new TestHistogram
+  override val connected     = new TestGauge
+  override val connections   = new TestCounter
 }

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/scaladsl/server/HttpMetricsDirectivesSpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/scaladsl/server/HttpMetricsDirectivesSpec.scala
@@ -30,9 +30,9 @@ class HttpMetricsDirectivesSpec extends AnyFlatSpec with Matchers with Scalatest
   import HttpMetricsDirectives._
 
   "HttpMetricsDirectives" should "expose the registry" in {
-    implicit val marshaller = StringMarshaller.compose[TestRegistry](r => s"active: ${r.active.value()}")
+    implicit val marshaller = StringMarshaller.compose[TestRegistry](r => s"active: ${r.requestsActive.value()}")
     val registry            = new TestRegistry()
-    registry.active.inc()
+    registry.requestsActive.inc()
 
     val route = path("metrics") {
       metrics(registry)

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
@@ -33,14 +33,14 @@ object DatadogRegistry {
 class DatadogRegistry(settings: HttpMetricsSettings)(implicit client: StatsDClient)
     extends HttpMetricsRegistry(settings) {
 
-  lazy val active: Gauge            = new StatsDGauge(settings.namespace, settings.metricsNames.activeRequests)
   lazy val requests: Counter        = new StatsDCounter(settings.namespace, settings.metricsNames.requests)
-  lazy val receivedBytes: Histogram = new StatsDHistogram(settings.namespace, settings.metricsNames.requestSizes)
+  lazy val requestsActive: Gauge    = new StatsDGauge(settings.namespace, settings.metricsNames.requestsActive)
+  lazy val requestsSize: Histogram  = new StatsDHistogram(settings.namespace, settings.metricsNames.requestsSize)
   lazy val responses: Counter       = new StatsDCounter(settings.namespace, settings.metricsNames.responses)
-  lazy val errors: Counter          = new StatsDCounter(settings.namespace, settings.metricsNames.errors)
-  lazy val duration: Timer          = new StatsDTimer(settings.namespace, settings.metricsNames.durations)
-  lazy val sentBytes: Histogram     = new StatsDHistogram(settings.namespace, settings.metricsNames.responseSizes)
-  lazy val connected: Gauge         = new StatsDGauge(settings.namespace, settings.metricsNames.activeConnections)
+  lazy val responsesErrors: Counter = new StatsDCounter(settings.namespace, settings.metricsNames.responsesErrors)
+  lazy val responsesDuration: Timer = new StatsDTimer(settings.namespace, settings.metricsNames.responsesDuration)
+  lazy val responsesSize: Histogram = new StatsDHistogram(settings.namespace, settings.metricsNames.responsesSize)
   lazy val connections: Counter     = new StatsDCounter(settings.namespace, settings.metricsNames.connections)
+  lazy val connectionsActive: Gauge = new StatsDGauge(settings.namespace, settings.metricsNames.connectionsActive)
 
 }

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogRegistry.scala
@@ -21,7 +21,7 @@ import fr.davit.akka.http.metrics.core.{HttpMetricsSettings, _}
 
 object DatadogRegistry {
 
-  def apply(client: StatsDClient, settings: HttpMetricsSettings = HttpMetricsSettings.default): DatadogRegistry = {
+  def apply(client: StatsDClient, settings: HttpMetricsSettings = DatadogSettings.default): DatadogRegistry = {
     new DatadogRegistry(settings)(client)
   }
 }
@@ -33,22 +33,14 @@ object DatadogRegistry {
 class DatadogRegistry(settings: HttpMetricsSettings)(implicit client: StatsDClient)
     extends HttpMetricsRegistry(settings) {
 
-  override lazy val active: Gauge = new StatsDGauge(settings.namespace, "requests_active")
-
-  override lazy val requests: Counter = new StatsDCounter(settings.namespace, "requests_count")
-
-  override lazy val receivedBytes: Histogram = new StatsDHistogram(settings.namespace, "requests_bytes")
-
-  override lazy val responses: Counter = new StatsDCounter(settings.namespace, "responses_count")
-
-  override lazy val errors: Counter = new StatsDCounter(settings.namespace, "responses_errors_count")
-
-  override lazy val duration: Timer = new StatsDTimer(settings.namespace, "responses_duration")
-
-  override lazy val sentBytes: Histogram = new StatsDHistogram(settings.namespace, "responses_bytes")
-
-  override lazy val connected: Gauge = new StatsDGauge(settings.namespace, "connections_active")
-
-  override lazy val connections: Counter = new StatsDCounter(settings.namespace, "connections_count")
+  lazy val active: Gauge            = new StatsDGauge(settings.namespace, settings.metricsNames.activeRequests)
+  lazy val requests: Counter        = new StatsDCounter(settings.namespace, settings.metricsNames.requests)
+  lazy val receivedBytes: Histogram = new StatsDHistogram(settings.namespace, settings.metricsNames.requestSizes)
+  lazy val responses: Counter       = new StatsDCounter(settings.namespace, settings.metricsNames.responses)
+  lazy val errors: Counter          = new StatsDCounter(settings.namespace, settings.metricsNames.errors)
+  lazy val duration: Timer          = new StatsDTimer(settings.namespace, settings.metricsNames.durations)
+  lazy val sentBytes: Histogram     = new StatsDHistogram(settings.namespace, settings.metricsNames.responseSizes)
+  lazy val connected: Gauge         = new StatsDGauge(settings.namespace, settings.metricsNames.activeConnections)
+  lazy val connections: Counter     = new StatsDCounter(settings.namespace, settings.metricsNames.connections)
 
 }

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
@@ -9,14 +9,14 @@ object DatadogMetricsNames {
 
   val default: HttpMetricsNames = HttpMetricsNamesImpl(
     requests = "requests_count",
-    activeRequests = "requests_active",
-    requestSizes = "requests_bytes",
+    requestsActive = "requests_active",
+    requestsSize = "requests_bytes",
     responses = "responses_count",
-    errors = "responses_errors_count",
-    durations = "responses_duration",
-    responseSizes = "responses_bytes",
+    responsesErrors = "responses_errors_count",
+    responsesDuration = "responses_duration",
+    responsesSize = "responses_bytes",
     connections = "connections_active",
-    activeConnections = "connections_count"
+    connectionsActive = "connections_count"
   )
 
 }

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.datadog
 
 import akka.http.scaladsl.model.StatusCodes

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
@@ -1,0 +1,35 @@
+package fr.davit.akka.http.metrics.datadog
+
+import akka.http.scaladsl.model.StatusCodes
+import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
+import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
+import fr.davit.akka.http.metrics.core.HttpMetricsSettings.HttpMetricsSettingsImpl
+
+object DatadogMetricsNames {
+
+  val default: HttpMetricsNames = HttpMetricsNamesImpl(
+    requests = "requests_count",
+    activeRequests = "requests_active",
+    requestSizes = "requests_bytes",
+    responses = "responses_count",
+    errors = "responses_errors_count",
+    durations = "responses_duration",
+    responseSizes = "responses_bytes",
+    connections = "connections_active",
+    activeConnections = "connections_count"
+  )
+
+}
+
+object DatadogSettings {
+
+  val default: HttpMetricsSettings = HttpMetricsSettingsImpl(
+    "akka.http",
+    DatadogMetricsNames.default,
+    _.status.isInstanceOf[StatusCodes.ServerError],
+    includeMethodDimension = false,
+    includePathDimension = false,
+    includeStatusDimension = false
+  )
+
+}

--- a/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
+++ b/datadog/src/main/scala/fr/davit/akka/http/metrics/datadog/DatadogSettings.scala
@@ -31,8 +31,8 @@ object DatadogMetricsNames {
     responsesErrors = "responses_errors_count",
     responsesDuration = "responses_duration",
     responsesSize = "responses_bytes",
-    connections = "connections_active",
-    connectionsActive = "connections_count"
+    connections = "connections_count",
+    connectionsActive = "connections_active"
   )
 
 }

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
@@ -23,7 +23,7 @@ object DropwizardRegistry {
 
   def apply(
       registry: MetricRegistry = new MetricRegistry(),
-      settings: HttpMetricsSettings = HttpMetricsSettings.default
+      settings: HttpMetricsSettings = DropwizardSettings.default
   ): DropwizardRegistry = {
     new DropwizardRegistry(settings)(registry)
   }
@@ -32,21 +32,13 @@ object DropwizardRegistry {
 class DropwizardRegistry(settings: HttpMetricsSettings)(implicit val underlying: MetricRegistry)
     extends HttpMetricsRegistry(settings) {
 
-  override lazy val active: Gauge = new DropwizardGauge(settings.namespace, "requests.active")
-
-  override lazy val requests: Counter = new DropwizardCounter(settings.namespace, "requests")
-
-  override lazy val receivedBytes: Histogram = new DropwizardHistogram(settings.namespace, "requests.bytes")
-
-  override lazy val responses: Counter = new DropwizardCounter(settings.namespace, "responses")
-
-  override lazy val errors: Counter = new DropwizardCounter(settings.namespace, "responses.errors")
-
-  override lazy val duration: Timer = new DropwizardTimer(settings.namespace, "responses.duration")
-
-  override lazy val sentBytes: Histogram = new DropwizardHistogram(settings.namespace, "responses.bytes")
-
-  override lazy val connected: Gauge = new DropwizardGauge(settings.namespace, "connections.active")
-
-  override lazy val connections: Counter = new DropwizardCounter(settings.namespace, "connections")
+  lazy val active: Gauge            = new DropwizardGauge(settings.namespace, settings.metricsNames.activeRequests)
+  lazy val requests: Counter        = new DropwizardCounter(settings.namespace, settings.metricsNames.requests)
+  lazy val receivedBytes: Histogram = new DropwizardHistogram(settings.namespace, settings.metricsNames.requestSizes)
+  lazy val responses: Counter       = new DropwizardCounter(settings.namespace, settings.metricsNames.responses)
+  lazy val errors: Counter          = new DropwizardCounter(settings.namespace, settings.metricsNames.errors)
+  lazy val duration: Timer          = new DropwizardTimer(settings.namespace, settings.metricsNames.durations)
+  lazy val sentBytes: Histogram     = new DropwizardHistogram(settings.namespace, settings.metricsNames.responseSizes)
+  lazy val connected: Gauge         = new DropwizardGauge(settings.namespace, settings.metricsNames.activeConnections)
+  lazy val connections: Counter     = new DropwizardCounter(settings.namespace, settings.metricsNames.connections)
 }

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
@@ -32,13 +32,13 @@ object DropwizardRegistry {
 class DropwizardRegistry(settings: HttpMetricsSettings)(implicit val underlying: MetricRegistry)
     extends HttpMetricsRegistry(settings) {
 
-  lazy val active: Gauge            = new DropwizardGauge(settings.namespace, settings.metricsNames.activeRequests)
   lazy val requests: Counter        = new DropwizardCounter(settings.namespace, settings.metricsNames.requests)
-  lazy val receivedBytes: Histogram = new DropwizardHistogram(settings.namespace, settings.metricsNames.requestSizes)
+  lazy val requestsActive: Gauge    = new DropwizardGauge(settings.namespace, settings.metricsNames.requestsActive)
+  lazy val requestsSize: Histogram  = new DropwizardHistogram(settings.namespace, settings.metricsNames.requestsSize)
   lazy val responses: Counter       = new DropwizardCounter(settings.namespace, settings.metricsNames.responses)
-  lazy val errors: Counter          = new DropwizardCounter(settings.namespace, settings.metricsNames.errors)
-  lazy val duration: Timer          = new DropwizardTimer(settings.namespace, settings.metricsNames.durations)
-  lazy val sentBytes: Histogram     = new DropwizardHistogram(settings.namespace, settings.metricsNames.responseSizes)
-  lazy val connected: Gauge         = new DropwizardGauge(settings.namespace, settings.metricsNames.activeConnections)
+  lazy val responsesErrors: Counter = new DropwizardCounter(settings.namespace, settings.metricsNames.responsesErrors)
+  lazy val responsesDuration: Timer = new DropwizardTimer(settings.namespace, settings.metricsNames.responsesDuration)
+  lazy val responsesSize: Histogram  = new DropwizardHistogram(settings.namespace, settings.metricsNames.responsesSize)
   lazy val connections: Counter     = new DropwizardCounter(settings.namespace, settings.metricsNames.connections)
+  lazy val connectionsActive: Gauge = new DropwizardGauge(settings.namespace, settings.metricsNames.connectionsActive)
 }

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistry.scala
@@ -38,7 +38,7 @@ class DropwizardRegistry(settings: HttpMetricsSettings)(implicit val underlying:
   lazy val responses: Counter       = new DropwizardCounter(settings.namespace, settings.metricsNames.responses)
   lazy val responsesErrors: Counter = new DropwizardCounter(settings.namespace, settings.metricsNames.responsesErrors)
   lazy val responsesDuration: Timer = new DropwizardTimer(settings.namespace, settings.metricsNames.responsesDuration)
-  lazy val responsesSize: Histogram  = new DropwizardHistogram(settings.namespace, settings.metricsNames.responsesSize)
+  lazy val responsesSize: Histogram = new DropwizardHistogram(settings.namespace, settings.metricsNames.responsesSize)
   lazy val connections: Counter     = new DropwizardCounter(settings.namespace, settings.metricsNames.connections)
   lazy val connectionsActive: Gauge = new DropwizardGauge(settings.namespace, settings.metricsNames.connectionsActive)
 }

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardSettings.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardSettings.scala
@@ -9,14 +9,14 @@ object DropwizardMetricsNames {
 
   val default: HttpMetricsNames = HttpMetricsNamesImpl(
     requests = "requests",
-    activeRequests = "requests.active",
-    requestSizes = "requests.bytes",
+    requestsActive = "requests.active",
+    requestsSize = "requests.bytes",
     responses = "responses",
-    errors = "responses.errors",
-    durations = "responses.duration",
-    responseSizes = "responses.bytes",
+    responsesErrors = "responses.errors",
+    responsesDuration = "responses.duration",
+    responsesSize = "responses.bytes",
     connections = "connections",
-    activeConnections = "connections.active"
+    connectionsActive = "connections.active"
   )
 
 }

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardSettings.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardSettings.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.dropwizard
 
 import akka.http.scaladsl.model.StatusCodes

--- a/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardSettings.scala
+++ b/dropwizard/src/main/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardSettings.scala
@@ -1,0 +1,35 @@
+package fr.davit.akka.http.metrics.dropwizard
+
+import akka.http.scaladsl.model.StatusCodes
+import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
+import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
+import fr.davit.akka.http.metrics.core.HttpMetricsSettings.HttpMetricsSettingsImpl
+
+object DropwizardMetricsNames {
+
+  val default: HttpMetricsNames = HttpMetricsNamesImpl(
+    requests = "requests",
+    activeRequests = "requests.active",
+    requestSizes = "requests.bytes",
+    responses = "responses",
+    errors = "responses.errors",
+    durations = "responses.duration",
+    responseSizes = "responses.bytes",
+    connections = "connections",
+    activeConnections = "connections.active"
+  )
+
+}
+
+object DropwizardSettings {
+
+  val default: HttpMetricsSettings = HttpMetricsSettingsImpl(
+    "akka.http",
+    DropwizardMetricsNames.default,
+    _.status.isInstanceOf[StatusCodes.ServerError],
+    includeMethodDimension = false,
+    includePathDimension = false,
+    includeStatusDimension = false
+  )
+
+}

--- a/dropwizard/src/test/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistrySpec.scala
+++ b/dropwizard/src/test/scala/fr/davit/akka/http/metrics/dropwizard/DropwizardRegistrySpec.scala
@@ -51,8 +51,8 @@ class DropwizardRegistrySpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  "DropwizardRegistry" should "set active metrics in the underlying registry" in new Fixture {
-    registry.active.inc()
+  "DropwizardRegistry" should "set requestsActive metrics in the underlying registry" in new Fixture {
+    registry.requestsActive.inc()
     underlyingCounter("akka.http.requests.active") shouldBe 1L
   }
 
@@ -61,8 +61,8 @@ class DropwizardRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounter("akka.http.requests") shouldBe 1L
   }
 
-  it should "set receivedBytes metrics in the underlying registry" in new Fixture {
-    registry.receivedBytes.update(3)
+  it should "set requestsSize metrics in the underlying registry" in new Fixture {
+    registry.requestsSize.update(3)
     underlyingHistogram("akka.http.requests.bytes") shouldBe 3L
   }
 
@@ -74,32 +74,32 @@ class DropwizardRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounter("akka.http.responses", dimensions) shouldBe 1L
   }
 
-  it should "set errors metrics in the underlying registry" in new Fixture {
-    registry.errors.inc()
+  it should "set responsesErrors metrics in the underlying registry" in new Fixture {
+    registry.responsesErrors.inc()
     underlyingCounter("akka.http.responses.errors") shouldBe 1L
 
-    registry.errors.inc(dimensions)
+    registry.responsesErrors.inc(dimensions)
     underlyingCounter("akka.http.responses.errors", dimensions) shouldBe 1L
   }
 
-  it should "set duration metrics in the underlying registry" in new Fixture {
-    registry.duration.observe(3.seconds)
+  it should "set responsesDuration metrics in the underlying registry" in new Fixture {
+    registry.responsesDuration.observe(3.seconds)
     underlyingTimer("akka.http.responses.duration") shouldBe 3000000000L
 
-    registry.duration.observe(3.seconds, dimensions)
+    registry.responsesDuration.observe(3.seconds, dimensions)
     underlyingTimer("akka.http.responses.duration", dimensions) shouldBe 3000000000L
   }
 
-  it should "set sentBytes metrics in the underlying registry" in new Fixture {
-    registry.sentBytes.update(3)
+  it should "set responsesSize metrics in the underlying registry" in new Fixture {
+    registry.responsesSize.update(3)
     underlyingHistogram("akka.http.responses.bytes") shouldBe 3L
 
-    registry.sentBytes.update(3, dimensions)
+    registry.responsesSize.update(3, dimensions)
     underlyingHistogram("akka.http.responses.bytes", dimensions) shouldBe 3L
   }
 
-  it should "set connected metrics in the underlying registry" in new Fixture {
-    registry.connected.inc()
+  it should "set connectionsActive metrics in the underlying registry" in new Fixture {
+    registry.connectionsActive.inc()
     underlyingCounter("akka.http.connections.active") shouldBe 1L
   }
 

--- a/dropwizard/src/test/scala/fr/davit/akka/http/metrics/dropwizard/marshalling/DropwizardMarshallersSpec.scala
+++ b/dropwizard/src/test/scala/fr/davit/akka/http/metrics/dropwizard/marshalling/DropwizardMarshallersSpec.scala
@@ -49,24 +49,28 @@ class DropwizardMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
     // use metrics so they appear in the report
     val dimensions = Seq(StatusGroupDimension(StatusCodes.OK))
     registry.requests.inc()
-    registry.receivedBytes.update(10)
-    registry.active.inc()
+    registry.requestsActive.inc()
+    registry.requestsSize.update(10)
     registry.responses.inc(dimensions)
-    registry.errors.inc()
-    registry.duration.observe(1.second, dimensions)
-    registry.sentBytes.update(10)
+    registry.responsesErrors.inc()
+    registry.responsesDuration.observe(1.second, dimensions)
+    registry.responsesSize.update(10)
+    registry.connections.inc()
+    registry.connectionsActive.inc()
 
     Get() ~> metrics(registry) ~> check {
       val json = responseAs[JsonResponse]
       // println(json)
       json.metrics.keys should contain theSameElementsAs Seq(
-        "akka.http.requests.active",
         "akka.http.requests",
+        "akka.http.requests.active",
         "akka.http.requests.bytes",
         "akka.http.responses{status=2xx}",
         "akka.http.responses.errors",
         "akka.http.responses.duration{status=2xx}",
         "akka.http.responses.bytes",
+        "akka.http.connections",
+        "akka.http.connections.active",
         "other.metric"
       ).toSet
     }

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteRegistry.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteRegistry.scala
@@ -28,13 +28,13 @@ object GraphiteRegistry {
 class GraphiteRegistry(settings: HttpMetricsSettings)(implicit client: CarbonClient)
     extends HttpMetricsRegistry(settings) {
 
-  lazy val active: Gauge            = new CarbonGauge(settings.namespace, settings.metricsNames.activeRequests)
   lazy val requests: Counter        = new CarbonCounter(settings.namespace, settings.metricsNames.requests)
-  lazy val receivedBytes: Histogram = new CarbonHistogram(settings.namespace, settings.metricsNames.requestSizes)
+  lazy val requestsActive: Gauge    = new CarbonGauge(settings.namespace, settings.metricsNames.requestsActive)
+  lazy val requestsSize: Histogram  = new CarbonHistogram(settings.namespace, settings.metricsNames.requestsSize)
   lazy val responses: Counter       = new CarbonCounter(settings.namespace, settings.metricsNames.responses)
-  lazy val errors: Counter          = new CarbonCounter(settings.namespace, settings.metricsNames.errors)
-  lazy val duration: Timer          = new CarbonTimer(settings.namespace, settings.metricsNames.durations)
-  lazy val sentBytes: Histogram     = new CarbonHistogram(settings.namespace, settings.metricsNames.responseSizes)
-  lazy val connected: Gauge         = new CarbonGauge(settings.namespace, settings.metricsNames.activeConnections)
+  lazy val responsesErrors: Counter = new CarbonCounter(settings.namespace, settings.metricsNames.responsesErrors)
+  lazy val responsesDuration: Timer = new CarbonTimer(settings.namespace, settings.metricsNames.responsesDuration)
+  lazy val responsesSize: Histogram = new CarbonHistogram(settings.namespace, settings.metricsNames.responsesSize)
   lazy val connections: Counter     = new CarbonCounter(settings.namespace, settings.metricsNames.connections)
+  lazy val connectionsActive: Gauge = new CarbonGauge(settings.namespace, settings.metricsNames.connectionsActive)
 }

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteRegistry.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteRegistry.scala
@@ -20,7 +20,7 @@ import fr.davit.akka.http.metrics.core.{HttpMetricsSettings, _}
 
 object GraphiteRegistry {
 
-  def apply(client: CarbonClient, settings: HttpMetricsSettings = HttpMetricsSettings.default): GraphiteRegistry = {
+  def apply(client: CarbonClient, settings: HttpMetricsSettings = GraphiteSettings.default): GraphiteRegistry = {
     new GraphiteRegistry(settings)(client)
   }
 }
@@ -28,21 +28,13 @@ object GraphiteRegistry {
 class GraphiteRegistry(settings: HttpMetricsSettings)(implicit client: CarbonClient)
     extends HttpMetricsRegistry(settings) {
 
-  override lazy val active: Gauge = new CarbonGauge(settings.namespace, "requests.active")
-
-  override lazy val requests: Counter = new CarbonCounter(settings.namespace, "requests")
-
-  override lazy val receivedBytes: Histogram = new CarbonHistogram(settings.namespace, "requests.bytes")
-
-  override lazy val responses: Counter = new CarbonCounter(settings.namespace, "responses")
-
-  override lazy val errors: Counter = new CarbonCounter(settings.namespace, "responses.errors")
-
-  override lazy val duration: Timer = new CarbonTimer(settings.namespace, "responses.duration")
-
-  override lazy val sentBytes: Histogram = new CarbonHistogram(settings.namespace, "responses.bytes")
-
-  override lazy val connected: Gauge = new CarbonGauge(settings.namespace, "connections.active")
-
-  override lazy val connections: Counter = new CarbonCounter(settings.namespace, "connections")
+  lazy val active: Gauge            = new CarbonGauge(settings.namespace, settings.metricsNames.activeRequests)
+  lazy val requests: Counter        = new CarbonCounter(settings.namespace, settings.metricsNames.requests)
+  lazy val receivedBytes: Histogram = new CarbonHistogram(settings.namespace, settings.metricsNames.requestSizes)
+  lazy val responses: Counter       = new CarbonCounter(settings.namespace, settings.metricsNames.responses)
+  lazy val errors: Counter          = new CarbonCounter(settings.namespace, settings.metricsNames.errors)
+  lazy val duration: Timer          = new CarbonTimer(settings.namespace, settings.metricsNames.durations)
+  lazy val sentBytes: Histogram     = new CarbonHistogram(settings.namespace, settings.metricsNames.responseSizes)
+  lazy val connected: Gauge         = new CarbonGauge(settings.namespace, settings.metricsNames.activeConnections)
+  lazy val connections: Counter     = new CarbonCounter(settings.namespace, settings.metricsNames.connections)
 }

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteSettings.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteSettings.scala
@@ -1,0 +1,35 @@
+package fr.davit.akka.http.metrics.graphite
+
+import akka.http.scaladsl.model.StatusCodes
+import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
+import fr.davit.akka.http.metrics.core.HttpMetricsSettings.HttpMetricsSettingsImpl
+import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
+
+object GraphiteMetricsNames {
+
+  val default: HttpMetricsNames = HttpMetricsNamesImpl(
+    requests = "requests",
+    activeRequests = "requests.active",
+    requestSizes = "requests.bytes",
+    responses = "responses",
+    errors = "responses.errors",
+    durations = "responses.duration",
+    responseSizes = "responses.bytes",
+    connections = "connections",
+    activeConnections = "connections.active"
+  )
+
+}
+
+object GraphiteSettings {
+
+  val default: HttpMetricsSettings = HttpMetricsSettingsImpl(
+    "akka.http",
+    GraphiteMetricsNames.default,
+    _.status.isInstanceOf[StatusCodes.ServerError],
+    includeMethodDimension = false,
+    includePathDimension = false,
+    includeStatusDimension = false
+  )
+
+}

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteSettings.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteSettings.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Michel Davit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.davit.akka.http.metrics.graphite
 
 import akka.http.scaladsl.model.StatusCodes

--- a/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteSettings.scala
+++ b/graphite/src/main/scala/fr/davit/akka/http/metrics/graphite/GraphiteSettings.scala
@@ -9,14 +9,14 @@ object GraphiteMetricsNames {
 
   val default: HttpMetricsNames = HttpMetricsNamesImpl(
     requests = "requests",
-    activeRequests = "requests.active",
-    requestSizes = "requests.bytes",
+    requestsActive = "requests.active",
+    requestsSize = "requests.bytes",
     responses = "responses",
-    errors = "responses.errors",
-    durations = "responses.duration",
-    responseSizes = "responses.bytes",
+    responsesErrors = "responses.errors",
+    responsesDuration = "responses.duration",
+    responsesSize = "responses.bytes",
     connections = "connections",
-    activeConnections = "connections.active"
+    connectionsActive = "connections.active"
   )
 
 }

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -58,21 +58,21 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     (methodLabel ++ pathLabel ++ statusLabel).toSeq
   }
 
-  override lazy val active: Gauge = io.prometheus.client.Gauge
+  lazy val active: Gauge = io.prometheus.client.Gauge
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.activeRequests)
     .help("Active HTTP requests")
     .register(underlying)
 
-  override lazy val requests: Counter = io.prometheus.client.Counter
+  lazy val requests: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.requests)
     .help("Total HTTP requests")
     .register(underlying)
 
-  override lazy val receivedBytes: Histogram = {
+  lazy val receivedBytes: Histogram = {
     val help = "HTTP request size"
     settings.receivedBytesConfig match {
       case Quantiles(qs, maxAge, ageBuckets) =>
@@ -97,7 +97,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     }
   }
 
-  override lazy val responses: Counter = io.prometheus.client.Counter
+  lazy val responses: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.responses)
@@ -105,7 +105,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .labelNames(labels: _*)
     .register(underlying)
 
-  override lazy val errors: Counter = io.prometheus.client.Counter
+  lazy val errors: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.errors)
@@ -113,7 +113,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .labelNames(labels: _*)
     .register(underlying)
 
-  override lazy val duration: Timer = {
+  lazy val duration: Timer = {
     val help = "HTTP response duration"
 
     settings.durationConfig match {
@@ -140,7 +140,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     }
   }
 
-  override lazy val sentBytes: Histogram = {
+  lazy val sentBytes: Histogram = {
     val help = "HTTP response size"
 
     settings.sentBytesConfig match {
@@ -168,14 +168,14 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     }
   }
 
-  override val connected: Gauge = io.prometheus.client.Gauge
+  lazy val connected: Gauge = io.prometheus.client.Gauge
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.activeConnections)
     .help("Active TCP connections")
     .register(underlying)
 
-  override val connections: Counter = io.prometheus.client.Counter
+  lazy val connections: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.connections)

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -58,13 +58,6 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     (methodLabel ++ pathLabel ++ statusLabel).toSeq
   }
 
-  lazy val active: Gauge = io.prometheus.client.Gauge
-    .build()
-    .namespace(settings.namespace)
-    .name(settings.metricsNames.activeRequests)
-    .help("Active HTTP requests")
-    .register(underlying)
-
   lazy val requests: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
@@ -72,14 +65,21 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .help("Total HTTP requests")
     .register(underlying)
 
-  lazy val receivedBytes: Histogram = {
+  lazy val requestsActive: Gauge = io.prometheus.client.Gauge
+    .build()
+    .namespace(settings.namespace)
+    .name(settings.metricsNames.requestsActive)
+    .help("Active HTTP requests")
+    .register(underlying)
+
+  lazy val requestsSize: Histogram = {
     val help = "HTTP request size"
     settings.receivedBytesConfig match {
       case Quantiles(qs, maxAge, ageBuckets) =>
         io.prometheus.client.Summary
           .build()
           .namespace(settings.namespace)
-          .name(settings.metricsNames.requestSizes)
+          .name(settings.metricsNames.requestsSize)
           .help(help)
           .quantiles(qs: _*)
           .maxAgeSeconds(maxAge.toSeconds)
@@ -90,7 +90,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Histogram
           .build()
           .namespace(settings.namespace)
-          .name(settings.metricsNames.requestSizes)
+          .name(settings.metricsNames.requestsSize)
           .help(help)
           .buckets(bs: _*)
           .register(underlying)
@@ -105,15 +105,15 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .labelNames(labels: _*)
     .register(underlying)
 
-  lazy val errors: Counter = io.prometheus.client.Counter
+  lazy val responsesErrors: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
-    .name(settings.metricsNames.errors)
+    .name(settings.metricsNames.responsesErrors)
     .help("Total HTTP errors")
     .labelNames(labels: _*)
     .register(underlying)
 
-  lazy val duration: Timer = {
+  lazy val responsesDuration: Timer = {
     val help = "HTTP response duration"
 
     settings.durationConfig match {
@@ -121,7 +121,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Summary
           .build()
           .namespace(settings.namespace)
-          .name(settings.metricsNames.durations)
+          .name(settings.metricsNames.responsesDuration)
           .help(help)
           .labelNames(labels: _*)
           .quantiles(qs: _*)
@@ -132,7 +132,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Histogram
           .build()
           .namespace(settings.namespace)
-          .name(settings.metricsNames.durations)
+          .name(settings.metricsNames.responsesDuration)
           .help(help)
           .labelNames(labels: _*)
           .buckets(bs: _*)
@@ -140,7 +140,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     }
   }
 
-  lazy val sentBytes: Histogram = {
+  lazy val responsesSize: Histogram = {
     val help = "HTTP response size"
 
     settings.sentBytesConfig match {
@@ -148,7 +148,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Summary
           .build()
           .namespace(settings.namespace)
-          .name(settings.metricsNames.responseSizes)
+          .name(settings.metricsNames.responsesSize)
           .help(help)
           .labelNames(labels: _*)
           .quantiles(qs: _*)
@@ -160,7 +160,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Histogram
           .build()
           .namespace(settings.namespace)
-          .name(settings.metricsNames.responseSizes)
+          .name(settings.metricsNames.responsesSize)
           .help(help)
           .labelNames(labels: _*)
           .buckets(bs: _*)
@@ -168,17 +168,17 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     }
   }
 
-  lazy val connected: Gauge = io.prometheus.client.Gauge
-    .build()
-    .namespace(settings.namespace)
-    .name(settings.metricsNames.activeConnections)
-    .help("Active TCP connections")
-    .register(underlying)
-
   lazy val connections: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
     .name(settings.metricsNames.connections)
     .help("Total TCP connections")
+    .register(underlying)
+
+  lazy val connectionsActive: Gauge = io.prometheus.client.Gauge
+    .build()
+    .namespace(settings.namespace)
+    .name(settings.metricsNames.connectionsActive)
+    .help("Active TCP connections")
     .register(underlying)
 }

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -61,26 +61,25 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   override lazy val active: Gauge = io.prometheus.client.Gauge
     .build()
     .namespace(settings.namespace)
-    .name("requests_active")
+    .name(settings.metricsNames.activeRequests)
     .help("Active HTTP requests")
     .register(underlying)
 
   override lazy val requests: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
-    .name("requests_total")
+    .name(settings.metricsNames.requests)
     .help("Total HTTP requests")
     .register(underlying)
 
   override lazy val receivedBytes: Histogram = {
-    val name = "requests_size_bytes"
     val help = "HTTP request size"
     settings.receivedBytesConfig match {
       case Quantiles(qs, maxAge, ageBuckets) =>
         io.prometheus.client.Summary
           .build()
           .namespace(settings.namespace)
-          .name(name)
+          .name(settings.metricsNames.requestSizes)
           .help(help)
           .quantiles(qs: _*)
           .maxAgeSeconds(maxAge.toSeconds)
@@ -91,7 +90,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Histogram
           .build()
           .namespace(settings.namespace)
-          .name(name)
+          .name(settings.metricsNames.requestSizes)
           .help(help)
           .buckets(bs: _*)
           .register(underlying)
@@ -101,7 +100,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   override lazy val responses: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
-    .name("responses_total")
+    .name(settings.metricsNames.responses)
     .help("HTTP responses")
     .labelNames(labels: _*)
     .register(underlying)
@@ -109,13 +108,12 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   override lazy val errors: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
-    .name("responses_errors_total")
+    .name(settings.metricsNames.errors)
     .help("Total HTTP errors")
     .labelNames(labels: _*)
     .register(underlying)
 
   override lazy val duration: Timer = {
-    val name = "responses_duration_seconds"
     val help = "HTTP response duration"
 
     settings.durationConfig match {
@@ -123,7 +121,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Summary
           .build()
           .namespace(settings.namespace)
-          .name(name)
+          .name(settings.metricsNames.durations)
           .help(help)
           .labelNames(labels: _*)
           .quantiles(qs: _*)
@@ -134,7 +132,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Histogram
           .build()
           .namespace(settings.namespace)
-          .name(name)
+          .name(settings.metricsNames.durations)
           .help(help)
           .labelNames(labels: _*)
           .buckets(bs: _*)
@@ -143,7 +141,6 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   }
 
   override lazy val sentBytes: Histogram = {
-    val name = "responses_size_bytes"
     val help = "HTTP response size"
 
     settings.sentBytesConfig match {
@@ -151,7 +148,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Summary
           .build()
           .namespace(settings.namespace)
-          .name(name)
+          .name(settings.metricsNames.responseSizes)
           .help(help)
           .labelNames(labels: _*)
           .quantiles(qs: _*)
@@ -163,7 +160,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
         io.prometheus.client.Histogram
           .build()
           .namespace(settings.namespace)
-          .name(name)
+          .name(settings.metricsNames.responseSizes)
           .help(help)
           .labelNames(labels: _*)
           .buckets(bs: _*)
@@ -174,14 +171,14 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   override val connected: Gauge = io.prometheus.client.Gauge
     .build()
     .namespace(settings.namespace)
-    .name("connections_active")
+    .name(settings.metricsNames.activeConnections)
     .help("Active TCP connections")
     .register(underlying)
 
   override val connections: Counter = io.prometheus.client.Counter
     .build()
     .namespace(settings.namespace)
-    .name("connections_total")
+    .name(settings.metricsNames.connections)
     .help("Total TCP connections")
     .register(underlying)
 }

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -17,7 +17,7 @@
 package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
-import fr.davit.akka.http.metrics.core.HttpMetricsSettings
+import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
 import fr.davit.akka.http.metrics.prometheus.Quantiles.Quantile
 
 import scala.concurrent.duration._
@@ -50,6 +50,21 @@ object Buckets {
   def apply(b: Double*): Buckets = Buckets(b.toList)
 }
 
+object PrometheusMetricsNames {
+
+  val default: HttpMetricsNames = HttpMetricsNames(
+    requests = "requests_total",
+    activeRequests = "requests_active",
+    requestSizes = "requests_size_bytes",
+    responses = "responses_total",
+    errors = "responses_errors_total",
+    durations = "responses_duration_seconds",
+    responseSizes = "responses_size_bytes",
+    connections = "connections_total",
+    activeConnections = "connections_active"
+  )
+}
+
 final case class PrometheusSettings(
     namespace: String,
     defineError: HttpResponse => Boolean,
@@ -58,7 +73,8 @@ final case class PrometheusSettings(
     includeStatusDimension: Boolean,
     receivedBytesConfig: HistogramConfig,
     durationConfig: TimerConfig,
-    sentBytesConfig: HistogramConfig
+    sentBytesConfig: HistogramConfig,
+    metricsNames: HttpMetricsNames
 ) extends HttpMetricsSettings {
 
   override def withNamespace(namespace: String): PrometheusSettings =
@@ -84,6 +100,9 @@ final case class PrometheusSettings(
 
   def withSentBytesConfig(config: HistogramConfig): PrometheusSettings =
     copy(sentBytesConfig = config)
+
+  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings =
+    copy(metricsNames = metricsNames)
 }
 
 object PrometheusSettings {
@@ -110,7 +129,7 @@ object PrometheusSettings {
     includeStatusDimension = false,
     receivedBytesConfig = BytesBuckets,
     durationConfig = DurationBuckets,
-    sentBytesConfig = BytesBuckets
+    sentBytesConfig = BytesBuckets,
+    metricsNames = PrometheusMetricsNames.default
   )
-
 }

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -55,14 +55,14 @@ object PrometheusMetricsNames {
 
   val default: HttpMetricsNames = HttpMetricsNamesImpl(
     requests = "requests_total",
-    activeRequests = "requests_active",
-    requestSizes = "requests_size_bytes",
+    requestsActive = "requests_active",
+    requestsSize = "requests_size_bytes",
     responses = "responses_total",
-    errors = "responses_errors_total",
-    durations = "responses_duration_seconds",
-    responseSizes = "responses_size_bytes",
+    responsesErrors = "responses_errors_total",
+    responsesDuration = "responses_duration_seconds",
+    responsesSize = "responses_size_bytes",
     connections = "connections_total",
-    activeConnections = "connections_active"
+    connectionsActive = "connections_active"
   )
 }
 

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -17,6 +17,7 @@
 package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
 import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
 import fr.davit.akka.http.metrics.prometheus.Quantiles.Quantile
 
@@ -52,7 +53,7 @@ object Buckets {
 
 object PrometheusMetricsNames {
 
-  val default: HttpMetricsNames = HttpMetricsNames(
+  val default: HttpMetricsNames = HttpMetricsNamesImpl(
     requests = "requests_total",
     activeRequests = "requests_active",
     requestSizes = "requests_size_bytes",

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -68,42 +68,26 @@ object PrometheusMetricsNames {
 
 final case class PrometheusSettings(
     namespace: String,
+    metricsNames: HttpMetricsNames,
     defineError: HttpResponse => Boolean,
     includeMethodDimension: Boolean,
     includePathDimension: Boolean,
     includeStatusDimension: Boolean,
     receivedBytesConfig: HistogramConfig,
     durationConfig: TimerConfig,
-    sentBytesConfig: HistogramConfig,
-    metricsNames: HttpMetricsNames
+    sentBytesConfig: HistogramConfig
 ) extends HttpMetricsSettings {
 
-  override def withNamespace(namespace: String): PrometheusSettings =
-    copy(namespace = namespace)
+  def withNamespace(namespace: String): PrometheusSettings                 = copy(namespace = namespace)
+  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings = copy(metricsNames = metricsNames)
+  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings     = copy(defineError = defineError)
+  def withIncludeMethodDimension(include: Boolean): PrometheusSettings     = copy(includeMethodDimension = include)
+  def withIncludePathDimension(include: Boolean): PrometheusSettings       = copy(includePathDimension = include)
+  def withIncludeStatusDimension(include: Boolean): PrometheusSettings     = copy(includeStatusDimension = include)
+  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings = copy(receivedBytesConfig = config)
+  def withDurationConfig(config: TimerConfig): PrometheusSettings          = copy(durationConfig = config)
+  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings     = copy(sentBytesConfig = config)
 
-  override def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings =
-    copy(defineError = defineError)
-
-  override def withIncludeMethodDimension(include: Boolean): PrometheusSettings =
-    copy(includeMethodDimension = include)
-
-  override def withIncludePathDimension(include: Boolean): PrometheusSettings =
-    copy(includePathDimension = include)
-
-  override def withIncludeStatusDimension(include: Boolean): PrometheusSettings =
-    copy(includeStatusDimension = include)
-
-  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings =
-    copy(receivedBytesConfig = config)
-
-  def withDurationConfig(config: TimerConfig): PrometheusSettings =
-    copy(durationConfig = config)
-
-  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings =
-    copy(sentBytesConfig = config)
-
-  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings =
-    copy(metricsNames = metricsNames)
 }
 
 object PrometheusSettings {

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -62,26 +62,26 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
         .withNamespace("test_server")
         .withMetricsNames(
           PrometheusMetricsNames.default
-            .withActiveConnections("test_connections_active")
-            .withActiveRequests("test_requests_active")
+            .withConnectionsActive("test_connections_active")
+            .withRequestsActive("test_requests_active")
             .withConnections("test_connections_total")
-            .withDurations("test_responses_duration_seconds")
-            .withErrors("test_responses_errors_total")
+            .withResponsesDuration("test_responses_duration_seconds")
+            .withResponsesErrors("test_responses_errors_total")
             .withRequests("test_requests_total")
-            .withRequestSizes("test_requests_size_bytes")
+            .withRequestSize("test_requests_size_bytes")
             .withResponses("test_responses_total")
-            .withResponseSizes("test_responses_size_bytes")
+            .withResponseSize("test_responses_size_bytes")
         )
     )
   }
 
-  it should "set active metrics in the underlying registry" in new Fixture {
-    registry.active.inc()
+  it should "set requestsActive metrics in the underlying registry" in new Fixture {
+    registry.requestsActive.inc()
     underlyingCounterValue("akka_http_requests_active") shouldBe 1L
   }
 
-  it should "set active metrics in the underlying registry using updated name" in new MetricsNamesFixture {
-    registry.active.inc()
+  it should "set requestsActive metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.requestsActive.inc()
     underlyingCounterValue("test_server_test_requests_active") shouldBe 1L
   }
 
@@ -95,13 +95,13 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounterValue("test_server_test_requests_total") shouldBe 1L
   }
 
-  it should "set receivedBytes metrics in the underlying registry" in new Fixture {
-    registry.receivedBytes.update(3)
+  it should "set requestsSize metrics in the underlying registry" in new Fixture {
+    registry.requestsSize.update(3)
     underlyingHistogramValue("akka_http_requests_size_bytes") shouldBe 3L
   }
 
-  it should "set receivedBytes metrics in the underlying registry using updated name" in new MetricsNamesFixture {
-    registry.receivedBytes.update(3)
+  it should "set requestsSize metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.requestsSize.update(3)
     underlyingHistogramValue("test_server_test_requests_size_bytes") shouldBe 3L
   }
 
@@ -120,58 +120,58 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounterValue("akka_http_responses_total", dimensions) shouldBe 1L
   }
 
-  it should "set errors metrics in the underlying registry" in new Fixture {
-    registry.errors.inc()
+  it should "set responsesErrors metrics in the underlying registry" in new Fixture {
+    registry.responsesErrors.inc()
     underlyingCounterValue("akka_http_responses_errors_total") shouldBe 1L
   }
 
-  it should "set errors metrics in the underlying registry using updated name" in new MetricsNamesFixture {
-    registry.errors.inc()
+  it should "set responsesErrors metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.responsesErrors.inc()
     underlyingCounterValue("test_server_test_responses_errors_total") shouldBe 1L
   }
 
-  it should "set errors metrics in the underlying registry with dimensions" in new DimensionFixture {
-    registry.errors.inc(dimensions)
+  it should "set responsesErrors metrics in the underlying registry with dimensions" in new DimensionFixture {
+    registry.responsesErrors.inc(dimensions)
     underlyingCounterValue("akka_http_responses_errors_total", dimensions) shouldBe 1L
   }
 
-  it should "set duration metrics in the underlying registry" in new Fixture {
-    registry.duration.observe(3.seconds)
+  it should "set responsesDuration metrics in the underlying registry" in new Fixture {
+    registry.responsesDuration.observe(3.seconds)
     underlyingHistogramValue("akka_http_responses_duration_seconds") shouldBe 3.0
   }
 
-  it should "set duration metrics in the underlying registry using updated name" in new MetricsNamesFixture {
-    registry.duration.observe(3.seconds)
+  it should "set responsesDuration metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.responsesDuration.observe(3.seconds)
     underlyingHistogramValue("test_server_test_responses_duration_seconds") shouldBe 3.0
   }
 
-  it should "set duration metrics in the underlying registry with dimension" in new DimensionFixture {
-    registry.duration.observe(3.seconds, dimensions)
+  it should "set responsesDuration metrics in the underlying registry with dimension" in new DimensionFixture {
+    registry.responsesDuration.observe(3.seconds, dimensions)
     underlyingHistogramValue("akka_http_responses_duration_seconds", dimensions) shouldBe 3.0
   }
 
-  it should "set sentBytes metrics in the underlying registry" in new Fixture {
-    registry.sentBytes.update(3)
+  it should "set responsesSize metrics in the underlying registry" in new Fixture {
+    registry.responsesSize.update(3)
     underlyingHistogramValue("akka_http_responses_size_bytes") shouldBe 3L
   }
 
-  it should "set sentBytes metrics in the underlying registry using updated name" in new MetricsNamesFixture {
-    registry.sentBytes.update(3)
+  it should "set responsesSize metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.responsesSize.update(3)
     underlyingHistogramValue("test_server_test_responses_size_bytes") shouldBe 3L
   }
 
-  it should "set sentBytes metrics in the underlying registry with dimensions" in new DimensionFixture {
-    registry.sentBytes.update(3, dimensions)
+  it should "set responsesSize metrics in the underlying registry with dimensions" in new DimensionFixture {
+    registry.responsesSize.update(3, dimensions)
     underlyingHistogramValue("akka_http_responses_size_bytes", dimensions) shouldBe 3L
   }
 
-  it should "set connected metrics in the underlying registry" in new Fixture {
-    registry.connected.inc()
+  it should "set connectionsActive metrics in the underlying registry" in new Fixture {
+    registry.connectionsActive.inc()
     underlyingCounterValue("akka_http_connections_active") shouldBe 1L
   }
 
-  it should "set connected metrics in the underlying registry using updated name" in new MetricsNamesFixture {
-    registry.connected.inc()
+  it should "set connectionsActive metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.connectionsActive.inc()
     underlyingCounterValue("test_server_test_connections_active") shouldBe 1L
   }
 

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -55,9 +55,32 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  trait MetricsNamesFixture extends Fixture {
+    override val registry = PrometheusRegistry(
+      new CollectorRegistry(),
+      PrometheusSettings.default.withMetricsNames(
+        PrometheusMetricsNames.default
+          .withActiveConnections("test_connections_active")
+          .withActiveRequests("test_requests_active")
+          .withConnections("test_connections_total")
+          .withDurations("test_responses_duration_seconds")
+          .withErrors("test_responses_errors_total")
+          .withRequests("test_requests_total")
+          .withRequestSizes("test_requests_size_bytes")
+          .withResponses("test_responses_total")
+          .withResponseSizes("test_responses_size_bytes")
+      )
+    )
+  }
+
   it should "set active metrics in the underlying registry" in new Fixture {
     registry.active.inc()
     underlyingCounterValue("akka_http_requests_active") shouldBe 1L
+  }
+
+  it should "set active metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.active.inc()
+    underlyingCounterValue("akka_http_test_requests_active") shouldBe 1L
   }
 
   it should "set requests metrics in the underlying registry" in new Fixture {
@@ -65,14 +88,29 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounterValue("akka_http_requests_total") shouldBe 1L
   }
 
+  it should "set requests metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.requests.inc()
+    underlyingCounterValue("akka_http_test_requests_total") shouldBe 1L
+  }
+
   it should "set receivedBytes metrics in the underlying registry" in new Fixture {
     registry.receivedBytes.update(3)
     underlyingHistogramValue("akka_http_requests_size_bytes") shouldBe 3L
   }
 
+  it should "set receivedBytes metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.receivedBytes.update(3)
+    underlyingHistogramValue("akka_http_test_requests_size_bytes") shouldBe 3L
+  }
+
   it should "set responses metrics in the underlying registry" in new Fixture {
     registry.responses.inc()
     underlyingCounterValue("akka_http_responses_total") shouldBe 1L
+  }
+
+  it should "set responses metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.responses.inc()
+    underlyingCounterValue("akka_http_test_responses_total") shouldBe 1L
   }
 
   it should "set responses metrics in the underlying registry with dimensions" in new DimensionFixture {
@@ -85,6 +123,11 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounterValue("akka_http_responses_errors_total") shouldBe 1L
   }
 
+  it should "set errors metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.errors.inc()
+    underlyingCounterValue("akka_http_test_responses_errors_total") shouldBe 1L
+  }
+
   it should "set errors metrics in the underlying registry with dimensions" in new DimensionFixture {
     registry.errors.inc(dimensions)
     underlyingCounterValue("akka_http_responses_errors_total", dimensions) shouldBe 1L
@@ -93,6 +136,11 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
   it should "set duration metrics in the underlying registry" in new Fixture {
     registry.duration.observe(3.seconds)
     underlyingHistogramValue("akka_http_responses_duration_seconds") shouldBe 3.0
+  }
+
+  it should "set duration metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.duration.observe(3.seconds)
+    underlyingHistogramValue("akka_http_test_responses_duration_seconds") shouldBe 3.0
   }
 
   it should "set duration metrics in the underlying registry with dimension" in new DimensionFixture {
@@ -105,6 +153,11 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingHistogramValue("akka_http_responses_size_bytes") shouldBe 3L
   }
 
+  it should "set sentBytes metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.sentBytes.update(3)
+    underlyingHistogramValue("akka_http_test_responses_size_bytes") shouldBe 3L
+  }
+
   it should "set sentBytes metrics in the underlying registry with dimensions" in new DimensionFixture {
     registry.sentBytes.update(3, dimensions)
     underlyingHistogramValue("akka_http_responses_size_bytes", dimensions) shouldBe 3L
@@ -115,8 +168,18 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
     underlyingCounterValue("akka_http_connections_active") shouldBe 1L
   }
 
+  it should "set connected metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.connected.inc()
+    underlyingCounterValue("akka_http_test_connections_active") shouldBe 1L
+  }
+
   it should "set connections metrics in the underlying registry" in new Fixture {
     registry.connections.inc()
     underlyingCounterValue("akka_http_connections_total") shouldBe 1L
+  }
+
+  it should "set connections metrics in the underlying registry using updated name" in new MetricsNamesFixture {
+    registry.connections.inc()
+    underlyingCounterValue("akka_http_test_connections_total") shouldBe 1L
   }
 }

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -58,18 +58,20 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
   trait MetricsNamesFixture extends Fixture {
     override val registry = PrometheusRegistry(
       new CollectorRegistry(),
-      PrometheusSettings.default.withMetricsNames(
-        PrometheusMetricsNames.default
-          .withActiveConnections("test_connections_active")
-          .withActiveRequests("test_requests_active")
-          .withConnections("test_connections_total")
-          .withDurations("test_responses_duration_seconds")
-          .withErrors("test_responses_errors_total")
-          .withRequests("test_requests_total")
-          .withRequestSizes("test_requests_size_bytes")
-          .withResponses("test_responses_total")
-          .withResponseSizes("test_responses_size_bytes")
-      )
+      PrometheusSettings.default
+        .withNamespace("test_server")
+        .withMetricsNames(
+          PrometheusMetricsNames.default
+            .withActiveConnections("test_connections_active")
+            .withActiveRequests("test_requests_active")
+            .withConnections("test_connections_total")
+            .withDurations("test_responses_duration_seconds")
+            .withErrors("test_responses_errors_total")
+            .withRequests("test_requests_total")
+            .withRequestSizes("test_requests_size_bytes")
+            .withResponses("test_responses_total")
+            .withResponseSizes("test_responses_size_bytes")
+        )
     )
   }
 
@@ -80,7 +82,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set active metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.active.inc()
-    underlyingCounterValue("akka_http_test_requests_active") shouldBe 1L
+    underlyingCounterValue("test_server_test_requests_active") shouldBe 1L
   }
 
   it should "set requests metrics in the underlying registry" in new Fixture {
@@ -90,7 +92,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set requests metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.requests.inc()
-    underlyingCounterValue("akka_http_test_requests_total") shouldBe 1L
+    underlyingCounterValue("test_server_test_requests_total") shouldBe 1L
   }
 
   it should "set receivedBytes metrics in the underlying registry" in new Fixture {
@@ -100,7 +102,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set receivedBytes metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.receivedBytes.update(3)
-    underlyingHistogramValue("akka_http_test_requests_size_bytes") shouldBe 3L
+    underlyingHistogramValue("test_server_test_requests_size_bytes") shouldBe 3L
   }
 
   it should "set responses metrics in the underlying registry" in new Fixture {
@@ -110,7 +112,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set responses metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.responses.inc()
-    underlyingCounterValue("akka_http_test_responses_total") shouldBe 1L
+    underlyingCounterValue("test_server_test_responses_total") shouldBe 1L
   }
 
   it should "set responses metrics in the underlying registry with dimensions" in new DimensionFixture {
@@ -125,7 +127,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set errors metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.errors.inc()
-    underlyingCounterValue("akka_http_test_responses_errors_total") shouldBe 1L
+    underlyingCounterValue("test_server_test_responses_errors_total") shouldBe 1L
   }
 
   it should "set errors metrics in the underlying registry with dimensions" in new DimensionFixture {
@@ -140,7 +142,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set duration metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.duration.observe(3.seconds)
-    underlyingHistogramValue("akka_http_test_responses_duration_seconds") shouldBe 3.0
+    underlyingHistogramValue("test_server_test_responses_duration_seconds") shouldBe 3.0
   }
 
   it should "set duration metrics in the underlying registry with dimension" in new DimensionFixture {
@@ -155,7 +157,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set sentBytes metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.sentBytes.update(3)
-    underlyingHistogramValue("akka_http_test_responses_size_bytes") shouldBe 3L
+    underlyingHistogramValue("test_server_test_responses_size_bytes") shouldBe 3L
   }
 
   it should "set sentBytes metrics in the underlying registry with dimensions" in new DimensionFixture {
@@ -170,7 +172,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set connected metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.connected.inc()
-    underlyingCounterValue("akka_http_test_connections_active") shouldBe 1L
+    underlyingCounterValue("test_server_test_connections_active") shouldBe 1L
   }
 
   it should "set connections metrics in the underlying registry" in new Fixture {
@@ -180,6 +182,6 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
   it should "set connections metrics in the underlying registry using updated name" in new MetricsNamesFixture {
     registry.connections.inc()
-    underlyingCounterValue("akka_http_test_connections_total") shouldBe 1L
+    underlyingCounterValue("test_server_test_connections_total") shouldBe 1L
   }
 }

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/marshalling/PrometheusMarshallersSpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/marshalling/PrometheusMarshallersSpec.scala
@@ -52,14 +52,14 @@ class PrometheusMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
     // use metrics so they appear in the report
     val dimensions = Seq(StatusGroupDimension(StatusCodes.OK))
     registry.requests.inc()
-    registry.receivedBytes.update(10)
-    registry.active.inc()
+    registry.requestsActive.inc()
+    registry.requestsSize.update(10)
     registry.responses.inc(dimensions)
-    registry.errors.inc(dimensions)
-    registry.duration.observe(1.second, dimensions)
-    registry.sentBytes.update(10, dimensions)
-    registry.connected.inc()
+    registry.responsesErrors.inc(dimensions)
+    registry.responsesDuration.observe(1.second, dimensions)
+    registry.responsesSize.update(10, dimensions)
     registry.connections.inc()
+    registry.connectionsActive.inc()
 
     Get() ~> metrics(registry) ~> check {
       response.entity.contentType shouldBe PrometheusMarshallers.PrometheusContentType
@@ -71,8 +71,8 @@ class PrometheusMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
         .map(_.takeWhile(c => c != ' ' && c != '{'))
         .distinct
       metrics should contain theSameElementsAs Seq(
-        "akka_http_requests_active",
         "akka_http_requests_total",
+        "akka_http_requests_active",
         "akka_http_requests_size_bytes_bucket",
         "akka_http_requests_size_bytes_count",
         "akka_http_requests_size_bytes_sum",
@@ -84,8 +84,8 @@ class PrometheusMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
         "akka_http_responses_size_bytes_bucket",
         "akka_http_responses_size_bytes_count",
         "akka_http_responses_size_bytes_sum",
-        "akka_http_connections_active",
         "akka_http_connections_total",
+        "akka_http_connections_active",
         "other_metric"
       )
     }

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/marshalling/PrometheusMarshallersSpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/marshalling/PrometheusMarshallersSpec.scala
@@ -58,6 +58,8 @@ class PrometheusMarshallersSpec extends AnyFlatSpec with Matchers with Scalatest
     registry.errors.inc(dimensions)
     registry.duration.observe(1.second, dimensions)
     registry.sentBytes.update(10, dimensions)
+    registry.connected.inc()
+    registry.connections.inc()
 
     Get() ~> metrics(registry) ~> check {
       response.entity.contentType shouldBe PrometheusMarshallers.PrometheusContentType


### PR DESCRIPTION
@RustedBones Can you please take a look at this PR related to #58 and let me know what you think.  So this is just a preliminary commit to the PR to get your opinion, on organization.   I went with just prometheus for now, since this one already has its own subclassed settings type.  One dilemma that I ran up again was as follows, on one sense it makes sense to make the metricsNames field part of the base HttpMetricsSettings trait whereas I implemented the metricsNames field directly on the PrometheusSettings type.  The reason for this is that there wasn't logical defaults to set for the metrics names which would in turn apply to all different implementations.  I'm not married to either idea, or if you have something else in mind please let me know.  Once we can get the organization sorted and prometheus implemented, I will move on to the other backends.