### PR TITLE
Adding support for custom server-level dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,17 @@ settings
   .withIncludeStatusDimension(true)
 ```
 
-Currently, Prometheus supports additional arbitrary server-level dimensions.
+You can also add additional static server-level dimensions to all metrics collected by the library. In the example
+below, the `env` label with `prod` dimension will be added. 
+
 ```scala
-settings
-  .serverDimensions(Seq[Dimension])
+import fr.davit.akka.http.metrics.core.Dimension
+
+final case class EnvDimension(value: String) extends Dimension {
+  override def key: String = "env"
+}
+
+settings.withServerDimensions(Seq(EnvDimension("prod")))
 ```
 
 These key/value pairs will be added to all response size and response duration metrics.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ settings
   .withIncludeStatusDimension(true)
 ```
 
+Currently, Prometheus supports additional arbitrary server-level dimensions.
+```scala
+settings
+  .serverDimensions(Seq[Dimension])
+```
+
+These key/value pairs will be added to all response size and response duration metrics.
+
+It is up to the implementor to implement a class extending the `Dimension` trait.
+
 ##### Method
 
 The method of the request is used as dimension on the metrics. eg. `GET`

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val commonSettings =
     Seq(
       organization := "fr.davit",
       organizationName := "Michel Davit",
-      version := "1.2.1-SNAPSHOT",
+      version := "1.2.2-SNAPSHOT",
       crossScalaVersions := (ThisBuild / crossScalaVersions).value,
       scalaVersion := crossScalaVersions.value.head,
       scalacOptions ~= filterScalacOptions,

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val commonSettings =
     Seq(
       organization := "fr.davit",
       organizationName := "Michel Davit",
-      version := "1.2.2-SNAPSHOT",
+      version := "1.3.0-SNAPSHOT",
       crossScalaVersions := (ThisBuild / crossScalaVersions).value,
       scalaVersion := crossScalaVersions.value.head,
       scalacOptions ~= filterScalacOptions,

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
@@ -58,6 +58,7 @@ object HttpMetricsRegistry {
     }
   }
 
+  final case class CustomDimension(key: String, value: String) extends Dimension {}
 }
 
 abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMetricsHandler {
@@ -125,7 +126,9 @@ abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMe
       val methodDim = if (settings.includeMethodDimension) Some(MethodDimension(request.method)) else None
       val pathDim = if (settings.includePathDimension) Some(PathDimension(pathLabel(r))) else None
       val statusGroupDim = if (settings.includeStatusDimension) Some(StatusGroupDimension(r.status)) else None
-      val dimensions = (methodDim ++ pathDim ++ statusGroupDim).toSeq
+      val customDims = settings.includeCustomLabels
+
+      val dimensions = (methodDim ++ pathDim ++ statusGroupDim).toSeq ++ customDims
       // format: on
 
       requestsActive.dec()

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
@@ -57,8 +57,6 @@ object HttpMetricsRegistry {
       case _                          => "other"
     }
   }
-
-  final case class CustomDimension(key: String, value: String) extends Dimension {}
 }
 
 abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMetricsHandler {
@@ -126,9 +124,9 @@ abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMe
       val methodDim = if (settings.includeMethodDimension) Some(MethodDimension(request.method)) else None
       val pathDim = if (settings.includePathDimension) Some(PathDimension(pathLabel(r))) else None
       val statusGroupDim = if (settings.includeStatusDimension) Some(StatusGroupDimension(r.status)) else None
-      val customDims = settings.includeCustomLabels
+      val serverDimensions = settings.serverDimensions
 
-      val dimensions = (methodDim ++ pathDim ++ statusGroupDim).toSeq ++ customDims
+      val dimensions = (methodDim ++ pathDim ++ statusGroupDim).toSeq ++ serverDimensions
       // format: on
 
       requestsActive.dec()

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
@@ -113,9 +113,11 @@ abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMe
   override def onRequest(request: HttpRequest, response: Future[HttpResponse])(
       implicit executionContext: ExecutionContext
   ): Unit = {
-    requestsActive.inc()
-    requests.inc()
-    requestsSize.update(request.entity.contentLengthOption.getOrElse(0L))
+    val serverDimensions = settings.serverDimensions
+
+    requestsActive.inc(serverDimensions)
+    requests.inc(serverDimensions)
+    requestsSize.update(request.entity.contentLengthOption.getOrElse(0L), serverDimensions)
     val start = Deadline.now
 
     response.foreach { r =>
@@ -124,12 +126,11 @@ abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMe
       val methodDim = if (settings.includeMethodDimension) Some(MethodDimension(request.method)) else None
       val pathDim = if (settings.includePathDimension) Some(PathDimension(pathLabel(r))) else None
       val statusGroupDim = if (settings.includeStatusDimension) Some(StatusGroupDimension(r.status)) else None
-      val serverDimensions = settings.serverDimensions
 
       val dimensions = (methodDim ++ pathDim ++ statusGroupDim).toSeq ++ serverDimensions
       // format: on
 
-      requestsActive.dec()
+      requestsActive.dec(serverDimensions)
       responses.inc(dimensions)
       responsesDuration.observe(Deadline.now - start, dimensions)
       if (settings.defineError(r)) {
@@ -140,8 +141,9 @@ abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMe
   }
 
   override def onConnection(completion: Future[Done])(implicit executionContext: ExecutionContext): Unit = {
-    connections.inc()
-    connectionsActive.inc()
-    completion.onComplete(_ => connectionsActive.dec())
+    val serverDimensions = settings.serverDimensions
+    connections.inc(serverDimensions)
+    connectionsActive.inc(serverDimensions)
+    completion.onComplete(_ => connectionsActive.dec(serverDimensions))
   }
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
@@ -63,7 +63,7 @@ trait HttpMetricsSettings {
   def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings
   def withIncludePathDimension(include: Boolean): HttpMetricsSettings
   def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings
-  def serverDimensions(labels: immutable.Seq[Dimension]): HttpMetricsSettings
+  def withServerDimensions(labels: immutable.Seq[Dimension]): HttpMetricsSettings
 }
 
 object HttpMetricsSettings {
@@ -96,12 +96,12 @@ object HttpMetricsSettings {
       serverDimensions: immutable.Seq[Dimension] = immutable.Seq.empty[Dimension]
   ) extends HttpMetricsSettings {
 
-    def withNamespace(namespace: String): HttpMetricsSettings                   = copy(namespace = namespace)
-    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings   = copy(metricsNames = metricsNames)
-    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings       = copy(defineError = fn)
-    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings       = copy(includeMethodDimension = include)
-    def withIncludePathDimension(include: Boolean): HttpMetricsSettings         = copy(includePathDimension = include)
-    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings       = copy(includeStatusDimension = include)
-    def serverDimensions(labels: immutable.Seq[Dimension]): HttpMetricsSettings = copy(serverDimensions = labels)
+    def withNamespace(namespace: String): HttpMetricsSettings                       = copy(namespace = namespace)
+    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings       = copy(metricsNames = metricsNames)
+    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings           = copy(defineError = fn)
+    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings           = copy(includeMethodDimension = include)
+    def withIncludePathDimension(include: Boolean): HttpMetricsSettings             = copy(includePathDimension = include)
+    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings           = copy(includeStatusDimension = include)
+    def withServerDimensions(labels: immutable.Seq[Dimension]): HttpMetricsSettings = copy(serverDimensions = labels)
   }
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
@@ -93,7 +93,7 @@ object HttpMetricsSettings {
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
       includeStatusDimension: Boolean,
-      serverDimensions: immutable.Seq[Dimension] = Seq.empty
+      serverDimensions: immutable.Seq[Dimension] = immutable.Seq.empty[Dimension]
   ) extends HttpMetricsSettings {
 
     def withNamespace(namespace: String): HttpMetricsSettings                   = copy(namespace = namespace)

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
@@ -17,7 +17,7 @@
 package fr.davit.akka.http.metrics.core
 
 import akka.http.scaladsl.model.HttpResponse
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.CustomDimension
+import scala.collection.immutable
 
 trait HttpMetricsSettings {
 
@@ -55,7 +55,7 @@ trait HttpMetricsSettings {
   /**
     * Include custom labels, using the Dimension object
     */
-  def includeCustomLabels: Seq[CustomDimension]
+  def serverDimensions: immutable.Seq[Dimension]
 
   def withNamespace(namespace: String): HttpMetricsSettings
   def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings
@@ -63,7 +63,7 @@ trait HttpMetricsSettings {
   def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings
   def withIncludePathDimension(include: Boolean): HttpMetricsSettings
   def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings
-  def withIncludeCustomLabels(labels: Seq[CustomDimension]): HttpMetricsSettings
+  def serverDimensions(labels: immutable.Seq[Dimension]): HttpMetricsSettings
 }
 
 object HttpMetricsSettings {
@@ -75,7 +75,7 @@ object HttpMetricsSettings {
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
       includeStatusDimension: Boolean,
-      includeCustomLabels: Seq[CustomDimension]
+      serverDimensions: immutable.Seq[Dimension]
   ): HttpMetricsSettings = HttpMetricsSettingsImpl(
     namespace,
     metricsNames,
@@ -83,7 +83,7 @@ object HttpMetricsSettings {
     includeMethodDimension,
     includePathDimension,
     includeStatusDimension,
-    includeCustomLabels
+    serverDimensions
   )
 
   private[metrics] case class HttpMetricsSettingsImpl(
@@ -93,15 +93,15 @@ object HttpMetricsSettings {
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
       includeStatusDimension: Boolean,
-      includeCustomLabels: Seq[CustomDimension] = Seq.empty
+      serverDimensions: immutable.Seq[Dimension] = Seq.empty
   ) extends HttpMetricsSettings {
 
-    def withNamespace(namespace: String): HttpMetricsSettings                      = copy(namespace = namespace)
-    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings      = copy(metricsNames = metricsNames)
-    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings          = copy(defineError = fn)
-    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings          = copy(includeMethodDimension = include)
-    def withIncludePathDimension(include: Boolean): HttpMetricsSettings            = copy(includePathDimension = include)
-    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings          = copy(includeStatusDimension = include)
-    def withIncludeCustomLabels(labels: Seq[CustomDimension]): HttpMetricsSettings = copy(includeCustomLabels = labels)
+    def withNamespace(namespace: String): HttpMetricsSettings                   = copy(namespace = namespace)
+    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings   = copy(metricsNames = metricsNames)
+    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings       = copy(defineError = fn)
+    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings       = copy(includeMethodDimension = include)
+    def withIncludePathDimension(include: Boolean): HttpMetricsSettings         = copy(includePathDimension = include)
+    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings       = copy(includeStatusDimension = include)
+    def serverDimensions(labels: immutable.Seq[Dimension]): HttpMetricsSettings = copy(serverDimensions = labels)
   }
 }

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
@@ -83,7 +83,7 @@ object HttpMetricsSettings {
     includeMethodDimension,
     includePathDimension,
     includeStatusDimension,
-    includeCustomLabels,
+    includeCustomLabels
   )
 
   private[metrics] case class HttpMetricsSettingsImpl(

--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsSettings.scala
@@ -17,6 +17,7 @@
 package fr.davit.akka.http.metrics.core
 
 import akka.http.scaladsl.model.HttpResponse
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.CustomDimension
 
 trait HttpMetricsSettings {
 
@@ -51,12 +52,18 @@ trait HttpMetricsSettings {
     */
   def includeStatusDimension: Boolean
 
+  /**
+    * Include custom labels, using the Dimension object
+    */
+  def includeCustomLabels: Seq[CustomDimension]
+
   def withNamespace(namespace: String): HttpMetricsSettings
   def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings
   def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings
   def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings
   def withIncludePathDimension(include: Boolean): HttpMetricsSettings
   def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings
+  def withIncludeCustomLabels(labels: Seq[CustomDimension]): HttpMetricsSettings
 }
 
 object HttpMetricsSettings {
@@ -67,14 +74,16 @@ object HttpMetricsSettings {
       defineError: HttpResponse => Boolean,
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
-      includeStatusDimension: Boolean
+      includeStatusDimension: Boolean,
+      includeCustomLabels: Seq[CustomDimension]
   ): HttpMetricsSettings = HttpMetricsSettingsImpl(
     namespace,
     metricsNames,
     defineError,
     includeMethodDimension,
     includePathDimension,
-    includeStatusDimension
+    includeStatusDimension,
+    includeCustomLabels,
   )
 
   private[metrics] case class HttpMetricsSettingsImpl(
@@ -83,15 +92,16 @@ object HttpMetricsSettings {
       defineError: HttpResponse => Boolean,
       includeMethodDimension: Boolean,
       includePathDimension: Boolean,
-      includeStatusDimension: Boolean
+      includeStatusDimension: Boolean,
+      includeCustomLabels: Seq[CustomDimension] = Seq.empty
   ) extends HttpMetricsSettings {
 
-    def withNamespace(namespace: String): HttpMetricsSettings                 = copy(namespace = namespace)
-    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings = copy(metricsNames = metricsNames)
-    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings     = copy(defineError = fn)
-    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings     = copy(includeMethodDimension = include)
-    def withIncludePathDimension(include: Boolean): HttpMetricsSettings       = copy(includePathDimension = include)
-    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings     = copy(includeStatusDimension = include)
-
+    def withNamespace(namespace: String): HttpMetricsSettings                      = copy(namespace = namespace)
+    def withMetricsNames(metricsNames: HttpMetricsNames): HttpMetricsSettings      = copy(metricsNames = metricsNames)
+    def withDefineError(fn: HttpResponse => Boolean): HttpMetricsSettings          = copy(defineError = fn)
+    def withIncludeMethodDimension(include: Boolean): HttpMetricsSettings          = copy(includeMethodDimension = include)
+    def withIncludePathDimension(include: Boolean): HttpMetricsSettings            = copy(includePathDimension = include)
+    def withIncludeStatusDimension(include: Boolean): HttpMetricsSettings          = copy(includeStatusDimension = include)
+    def withIncludeCustomLabels(labels: Seq[CustomDimension]): HttpMetricsSettings = copy(includeCustomLabels = labels)
   }
 }

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
@@ -32,7 +32,7 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
   implicit val currentThreadExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(_.run())
 
   final case object TestDimension extends Dimension {
-    override def key: String = "env"
+    override def key: String   = "env"
     override def value: String = "test"
   }
 

--- a/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
+++ b/core/src/test/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistrySpec.scala
@@ -31,6 +31,11 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
 
   implicit val currentThreadExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(_.run())
 
+  final case object TestDimension extends Dimension {
+    override def key: String = "env"
+    override def value: String = "test"
+  }
+
   abstract class Fixture(settings: HttpMetricsSettings = TestRegistry.settings) {
     val registry = new TestRegistry(settings)
   }
@@ -141,5 +146,16 @@ class HttpMetricsRegistrySpec extends AnyFlatSpec with Matchers with Eventually 
     )
     registry.responses.value(Seq(PathDimension(label))) shouldBe 1
     registry.responses.value(Seq(PathDimension("unlabelled"))) shouldBe 0
+  }
+
+  it should "increment proper custom dimension" in new Fixture(
+    TestRegistry.settings.withServerDimensions(List(TestDimension))
+  ) {
+    registry.onConnection(Future.successful(Done))
+    registry.connections.value(Seq(TestDimension)) shouldBe 1
+
+    registry.onRequest(HttpRequest(), Future.successful(HttpResponse()))
+    registry.requests.value(Seq(TestDimension)) shouldBe 1
+    registry.responses.value(Seq(TestDimension)) shouldBe 1
   }
 }

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -55,9 +55,9 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     val methodLabel  = if (settings.includeMethodDimension) Some(MethodDimension.Key) else None
     val pathLabel    = if (settings.includePathDimension) Some(PathDimension.Key) else None
     val statusLabel  = if (settings.includeStatusDimension) Some(StatusGroupDimension.Key) else None
-    val customLabels = settings.includeCustomLabels.map(_.key)
+    val serverLabels = settings.serverDimensions.map(_.key)
 
-    (methodLabel ++ pathLabel ++ statusLabel ++ customLabels).toSeq
+    (methodLabel ++ pathLabel ++ statusLabel ++ serverLabels).toSeq
   }
 
   lazy val requests: Counter = io.prometheus.client.Counter

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -52,9 +52,9 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   import PrometheusRegistry._
 
   private val labels: Seq[String] = {
-    val methodLabel = if (settings.includeMethodDimension) Some(MethodDimension.Key) else None
-    val pathLabel   = if (settings.includePathDimension) Some(PathDimension.Key) else None
-    val statusLabel = if (settings.includeStatusDimension) Some(StatusGroupDimension.Key) else None
+    val methodLabel  = if (settings.includeMethodDimension) Some(MethodDimension.Key) else None
+    val pathLabel    = if (settings.includePathDimension) Some(PathDimension.Key) else None
+    val statusLabel  = if (settings.includeStatusDimension) Some(StatusGroupDimension.Key) else None
     val customLabels = settings.includeCustomLabels.map(_.key)
 
     (methodLabel ++ pathLabel ++ statusLabel ++ customLabels).toSeq

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -51,11 +51,12 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
   import PrometheusConverters._
   import PrometheusRegistry._
 
+  private val serverLabels: Seq[String] = settings.serverDimensions.map(_.key)
+
   private val labels: Seq[String] = {
-    val methodLabel  = if (settings.includeMethodDimension) Some(MethodDimension.Key) else None
-    val pathLabel    = if (settings.includePathDimension) Some(PathDimension.Key) else None
-    val statusLabel  = if (settings.includeStatusDimension) Some(StatusGroupDimension.Key) else None
-    val serverLabels = settings.serverDimensions.map(_.key)
+    val methodLabel = if (settings.includeMethodDimension) Some(MethodDimension.Key) else None
+    val pathLabel   = if (settings.includePathDimension) Some(PathDimension.Key) else None
+    val statusLabel = if (settings.includeStatusDimension) Some(StatusGroupDimension.Key) else None
 
     (methodLabel ++ pathLabel ++ statusLabel ++ serverLabels).toSeq
   }
@@ -65,6 +66,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .namespace(settings.namespace)
     .name(settings.metricsNames.requests)
     .help("Total HTTP requests")
+    .labelNames(serverLabels: _*)
     .register(underlying)
 
   lazy val requestsActive: Gauge = io.prometheus.client.Gauge
@@ -72,6 +74,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .namespace(settings.namespace)
     .name(settings.metricsNames.requestsActive)
     .help("Active HTTP requests")
+    .labelNames(serverLabels: _*)
     .register(underlying)
 
   lazy val requestsSize: Histogram = {
@@ -83,6 +86,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
           .namespace(settings.namespace)
           .name(settings.metricsNames.requestsSize)
           .help(help)
+          .labelNames(serverLabels: _*)
           .quantiles(qs: _*)
           .maxAgeSeconds(maxAge.toSeconds)
           .ageBuckets(ageBuckets)
@@ -94,6 +98,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
           .namespace(settings.namespace)
           .name(settings.metricsNames.requestsSize)
           .help(help)
+          .labelNames(serverLabels: _*)
           .buckets(bs: _*)
           .register(underlying)
     }
@@ -175,6 +180,7 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .namespace(settings.namespace)
     .name(settings.metricsNames.connections)
     .help("Total TCP connections")
+    .labelNames(serverLabels: _*)
     .register(underlying)
 
   lazy val connectionsActive: Gauge = io.prometheus.client.Gauge
@@ -182,5 +188,6 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     .namespace(settings.namespace)
     .name(settings.metricsNames.connectionsActive)
     .help("Active TCP connections")
+    .labelNames(serverLabels: _*)
     .register(underlying)
 }

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistry.scala
@@ -55,7 +55,9 @@ class PrometheusRegistry(settings: PrometheusSettings, val underlying: Collector
     val methodLabel = if (settings.includeMethodDimension) Some(MethodDimension.Key) else None
     val pathLabel   = if (settings.includePathDimension) Some(PathDimension.Key) else None
     val statusLabel = if (settings.includeStatusDimension) Some(StatusGroupDimension.Key) else None
-    (methodLabel ++ pathLabel ++ statusLabel).toSeq
+    val customLabels = settings.includeCustomLabels.map(_.key)
+
+    (methodLabel ++ pathLabel ++ statusLabel ++ customLabels).toSeq
   }
 
   lazy val requests: Counter = io.prometheus.client.Counter

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -86,7 +86,7 @@ final case class PrometheusSettings(
   def withIncludeMethodDimension(include: Boolean): PrometheusSettings       = copy(includeMethodDimension = include)
   def withIncludePathDimension(include: Boolean): PrometheusSettings         = copy(includePathDimension = include)
   def withIncludeStatusDimension(include: Boolean): PrometheusSettings       = copy(includeStatusDimension = include)
-  def serverDimensions(labels: immutable.Seq[Dimension]): PrometheusSettings = copy(serverDimensions = labels)
+  def withServerDimensions(labels: immutable.Seq[Dimension]): PrometheusSettings = copy(serverDimensions = labels)
   def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings   = copy(receivedBytesConfig = config)
   def withDurationConfig(config: TimerConfig): PrometheusSettings            = copy(durationConfig = config)
   def withSentBytesConfig(config: HistogramConfig): PrometheusSettings       = copy(sentBytesConfig = config)

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -74,7 +74,7 @@ final case class PrometheusSettings(
     includeMethodDimension: Boolean,
     includePathDimension: Boolean,
     includeStatusDimension: Boolean,
-    serverDimensions: immutable.Seq[Dimension] = Seq.empty,
+    serverDimensions: immutable.Seq[Dimension] = immutable.Seq.empty[Dimension],
     receivedBytesConfig: HistogramConfig,
     durationConfig: TimerConfig,
     sentBytesConfig: HistogramConfig
@@ -114,7 +114,7 @@ object PrometheusSettings {
     includeMethodDimension = false,
     includePathDimension = false,
     includeStatusDimension = false,
-    serverDimensions = Seq.empty,
+    serverDimensions = immutable.Seq.empty[Dimension],
     receivedBytesConfig = BytesBuckets,
     durationConfig = DurationBuckets,
     sentBytesConfig = BytesBuckets,

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -18,6 +18,7 @@ package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.CustomDimension
 import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
 import fr.davit.akka.http.metrics.prometheus.Quantiles.Quantile
 
@@ -73,21 +74,22 @@ final case class PrometheusSettings(
     includeMethodDimension: Boolean,
     includePathDimension: Boolean,
     includeStatusDimension: Boolean,
+    includeCustomLabels: Seq[CustomDimension] = Seq.empty,
     receivedBytesConfig: HistogramConfig,
     durationConfig: TimerConfig,
     sentBytesConfig: HistogramConfig
 ) extends HttpMetricsSettings {
 
-  def withNamespace(namespace: String): PrometheusSettings                 = copy(namespace = namespace)
-  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings = copy(metricsNames = metricsNames)
-  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings     = copy(defineError = defineError)
-  def withIncludeMethodDimension(include: Boolean): PrometheusSettings     = copy(includeMethodDimension = include)
-  def withIncludePathDimension(include: Boolean): PrometheusSettings       = copy(includePathDimension = include)
-  def withIncludeStatusDimension(include: Boolean): PrometheusSettings     = copy(includeStatusDimension = include)
-  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings = copy(receivedBytesConfig = config)
-  def withDurationConfig(config: TimerConfig): PrometheusSettings          = copy(durationConfig = config)
-  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings     = copy(sentBytesConfig = config)
-
+  def withNamespace(namespace: String): PrometheusSettings                      = copy(namespace = namespace)
+  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings      = copy(metricsNames = metricsNames)
+  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings          = copy(defineError = defineError)
+  def withIncludeMethodDimension(include: Boolean): PrometheusSettings          = copy(includeMethodDimension = include)
+  def withIncludePathDimension(include: Boolean): PrometheusSettings            = copy(includePathDimension = include)
+  def withIncludeStatusDimension(include: Boolean): PrometheusSettings          = copy(includeStatusDimension = include)
+  def withIncludeCustomLabels(labels: Seq[CustomDimension]): PrometheusSettings = copy(includeCustomLabels = labels)
+  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings      = copy(receivedBytesConfig = config)
+  def withDurationConfig(config: TimerConfig): PrometheusSettings               = copy(durationConfig = config)
+  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings          = copy(sentBytesConfig = config)
 }
 
 object PrometheusSettings {
@@ -112,6 +114,7 @@ object PrometheusSettings {
     includeMethodDimension = false,
     includePathDimension = false,
     includeStatusDimension = false,
+    includeCustomLabels = Seq.empty,
     receivedBytesConfig = BytesBuckets,
     durationConfig = DurationBuckets,
     sentBytesConfig = BytesBuckets,

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -80,16 +80,16 @@ final case class PrometheusSettings(
     sentBytesConfig: HistogramConfig
 ) extends HttpMetricsSettings {
 
-  def withNamespace(namespace: String): PrometheusSettings                 = copy(namespace = namespace)
-  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings = copy(metricsNames = metricsNames)
-  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings     = copy(defineError = defineError)
-  def withIncludeMethodDimension(include: Boolean): PrometheusSettings     = copy(includeMethodDimension = include)
-  def withIncludePathDimension(include: Boolean): PrometheusSettings       = copy(includePathDimension = include)
-  def withIncludeStatusDimension(include: Boolean): PrometheusSettings     = copy(includeStatusDimension = include)
-  def serverDimensions(labels: Seq[Dimension]): PrometheusSettings         = copy(serverDimensions = labels)
-  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings = copy(receivedBytesConfig = config)
-  def withDurationConfig(config: TimerConfig): PrometheusSettings          = copy(durationConfig = config)
-  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings     = copy(sentBytesConfig = config)
+  def withNamespace(namespace: String): PrometheusSettings                   = copy(namespace = namespace)
+  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings   = copy(metricsNames = metricsNames)
+  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings       = copy(defineError = defineError)
+  def withIncludeMethodDimension(include: Boolean): PrometheusSettings       = copy(includeMethodDimension = include)
+  def withIncludePathDimension(include: Boolean): PrometheusSettings         = copy(includePathDimension = include)
+  def withIncludeStatusDimension(include: Boolean): PrometheusSettings       = copy(includeStatusDimension = include)
+  def serverDimensions(labels: immutable.Seq[Dimension]): PrometheusSettings = copy(serverDimensions = labels)
+  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings   = copy(receivedBytesConfig = config)
+  def withDurationConfig(config: TimerConfig): PrometheusSettings            = copy(durationConfig = config)
+  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings       = copy(sentBytesConfig = config)
 }
 
 object PrometheusSettings {

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -80,16 +80,16 @@ final case class PrometheusSettings(
     sentBytesConfig: HistogramConfig
 ) extends HttpMetricsSettings {
 
-  def withNamespace(namespace: String): PrometheusSettings                   = copy(namespace = namespace)
-  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings   = copy(metricsNames = metricsNames)
-  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings       = copy(defineError = defineError)
-  def withIncludeMethodDimension(include: Boolean): PrometheusSettings       = copy(includeMethodDimension = include)
-  def withIncludePathDimension(include: Boolean): PrometheusSettings         = copy(includePathDimension = include)
-  def withIncludeStatusDimension(include: Boolean): PrometheusSettings       = copy(includeStatusDimension = include)
+  def withNamespace(namespace: String): PrometheusSettings                       = copy(namespace = namespace)
+  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings       = copy(metricsNames = metricsNames)
+  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings           = copy(defineError = defineError)
+  def withIncludeMethodDimension(include: Boolean): PrometheusSettings           = copy(includeMethodDimension = include)
+  def withIncludePathDimension(include: Boolean): PrometheusSettings             = copy(includePathDimension = include)
+  def withIncludeStatusDimension(include: Boolean): PrometheusSettings           = copy(includeStatusDimension = include)
   def withServerDimensions(labels: immutable.Seq[Dimension]): PrometheusSettings = copy(serverDimensions = labels)
-  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings   = copy(receivedBytesConfig = config)
-  def withDurationConfig(config: TimerConfig): PrometheusSettings            = copy(durationConfig = config)
-  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings       = copy(sentBytesConfig = config)
+  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings       = copy(receivedBytesConfig = config)
+  def withDurationConfig(config: TimerConfig): PrometheusSettings                = copy(durationConfig = config)
+  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings           = copy(sentBytesConfig = config)
 }
 
 object PrometheusSettings {

--- a/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
+++ b/prometheus/src/main/scala/fr/davit/akka/http/metrics/prometheus/PrometheusSettings.scala
@@ -18,10 +18,10 @@ package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import fr.davit.akka.http.metrics.core.HttpMetricsNames.HttpMetricsNamesImpl
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.CustomDimension
-import fr.davit.akka.http.metrics.core.{HttpMetricsNames, HttpMetricsSettings}
+import fr.davit.akka.http.metrics.core.{Dimension, HttpMetricsNames, HttpMetricsSettings}
 import fr.davit.akka.http.metrics.prometheus.Quantiles.Quantile
 
+import scala.collection.immutable
 import scala.concurrent.duration._
 
 sealed trait HistogramConfig
@@ -74,22 +74,22 @@ final case class PrometheusSettings(
     includeMethodDimension: Boolean,
     includePathDimension: Boolean,
     includeStatusDimension: Boolean,
-    includeCustomLabels: Seq[CustomDimension] = Seq.empty,
+    serverDimensions: immutable.Seq[Dimension] = Seq.empty,
     receivedBytesConfig: HistogramConfig,
     durationConfig: TimerConfig,
     sentBytesConfig: HistogramConfig
 ) extends HttpMetricsSettings {
 
-  def withNamespace(namespace: String): PrometheusSettings                      = copy(namespace = namespace)
-  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings      = copy(metricsNames = metricsNames)
-  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings          = copy(defineError = defineError)
-  def withIncludeMethodDimension(include: Boolean): PrometheusSettings          = copy(includeMethodDimension = include)
-  def withIncludePathDimension(include: Boolean): PrometheusSettings            = copy(includePathDimension = include)
-  def withIncludeStatusDimension(include: Boolean): PrometheusSettings          = copy(includeStatusDimension = include)
-  def withIncludeCustomLabels(labels: Seq[CustomDimension]): PrometheusSettings = copy(includeCustomLabels = labels)
-  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings      = copy(receivedBytesConfig = config)
-  def withDurationConfig(config: TimerConfig): PrometheusSettings               = copy(durationConfig = config)
-  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings          = copy(sentBytesConfig = config)
+  def withNamespace(namespace: String): PrometheusSettings                 = copy(namespace = namespace)
+  def withMetricsNames(metricsNames: HttpMetricsNames): PrometheusSettings = copy(metricsNames = metricsNames)
+  def withDefineError(fn: HttpResponse => Boolean): PrometheusSettings     = copy(defineError = defineError)
+  def withIncludeMethodDimension(include: Boolean): PrometheusSettings     = copy(includeMethodDimension = include)
+  def withIncludePathDimension(include: Boolean): PrometheusSettings       = copy(includePathDimension = include)
+  def withIncludeStatusDimension(include: Boolean): PrometheusSettings     = copy(includeStatusDimension = include)
+  def serverDimensions(labels: Seq[Dimension]): PrometheusSettings         = copy(serverDimensions = labels)
+  def withReceivedBytesConfig(config: HistogramConfig): PrometheusSettings = copy(receivedBytesConfig = config)
+  def withDurationConfig(config: TimerConfig): PrometheusSettings          = copy(durationConfig = config)
+  def withSentBytesConfig(config: HistogramConfig): PrometheusSettings     = copy(sentBytesConfig = config)
 }
 
 object PrometheusSettings {
@@ -114,7 +114,7 @@ object PrometheusSettings {
     includeMethodDimension = false,
     includePathDimension = false,
     includeStatusDimension = false,
-    includeCustomLabels = Seq.empty,
+    serverDimensions = Seq.empty,
     receivedBytesConfig = BytesBuckets,
     durationConfig = DurationBuckets,
     sentBytesConfig = BytesBuckets,

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -18,7 +18,12 @@ package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpMethods, StatusCodes}
 import fr.davit.akka.http.metrics.core.Dimension
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{CustomDimension, MethodDimension, PathDimension, StatusGroupDimension}
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{
+  CustomDimension,
+  MethodDimension,
+  PathDimension,
+  StatusGroupDimension
+}
 import io.prometheus.client.CollectorRegistry
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -34,7 +39,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
   val dimensions = Seq(
     MethodDimension(HttpMethods.GET),
     PathDimension("/api"),
-    StatusGroupDimension(StatusCodes.OK),
+    StatusGroupDimension(StatusCodes.OK)
   ) ++ customDimensions
 
   trait Fixture {

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -59,7 +59,6 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
         .withIncludeMethodDimension(true)
         .withIncludePathDimension(true)
         .withIncludeStatusDimension(true)
-        .serverDimensions(customDimensions)
     )
   }
 

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -18,11 +18,7 @@ package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpMethods, StatusCodes}
 import fr.davit.akka.http.metrics.core.Dimension
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{
-  MethodDimension,
-  PathDimension,
-  StatusGroupDimension
-}
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{MethodDimension, PathDimension, StatusGroupDimension}
 import io.prometheus.client.CollectorRegistry
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -19,7 +19,6 @@ package fr.davit.akka.http.metrics.prometheus
 import akka.http.scaladsl.model.{HttpMethods, StatusCodes}
 import fr.davit.akka.http.metrics.core.Dimension
 import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{
-  CustomDimension,
   MethodDimension,
   PathDimension,
   StatusGroupDimension
@@ -29,6 +28,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
+
+case class CustomDimension(key: String, value: String) extends Dimension {}
 
 class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
@@ -61,7 +62,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
         .withIncludeMethodDimension(true)
         .withIncludePathDimension(true)
         .withIncludeStatusDimension(true)
-        .withIncludeCustomLabels(customDimensions)
+        .serverDimensions(customDimensions)
     )
   }
 

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -18,7 +18,7 @@ package fr.davit.akka.http.metrics.prometheus
 
 import akka.http.scaladsl.model.{HttpMethods, StatusCodes}
 import fr.davit.akka.http.metrics.core.Dimension
-import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{MethodDimension, PathDimension, StatusGroupDimension}
+import fr.davit.akka.http.metrics.core.HttpMetricsRegistry.{CustomDimension, MethodDimension, PathDimension, StatusGroupDimension}
 import io.prometheus.client.CollectorRegistry
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -27,11 +27,15 @@ import scala.concurrent.duration._
 
 class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
+  val customDimensions = Seq(
+    CustomDimension("test_key", "test_value")
+  )
+
   val dimensions = Seq(
     MethodDimension(HttpMethods.GET),
     PathDimension("/api"),
-    StatusGroupDimension(StatusCodes.OK)
-  )
+    StatusGroupDimension(StatusCodes.OK),
+  ) ++ customDimensions
 
   trait Fixture {
     val registry = PrometheusRegistry(new CollectorRegistry())
@@ -52,6 +56,7 @@ class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
         .withIncludeMethodDimension(true)
         .withIncludePathDimension(true)
         .withIncludeStatusDimension(true)
+        .withIncludeCustomLabels(customDimensions)
     )
   }
 

--- a/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/prometheus/src/test/scala/fr/davit/akka/http/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -23,13 +23,14 @@ import io.prometheus.client.CollectorRegistry
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.collection.immutable
 import scala.concurrent.duration._
 
 case class CustomDimension(key: String, value: String) extends Dimension {}
 
 class PrometheusRegistrySpec extends AnyFlatSpec with Matchers {
 
-  val customDimensions = Seq(
+  val customDimensions = immutable.Seq(
     CustomDimension("test_key", "test_value")
   )
 


### PR DESCRIPTION
This is a POC implementation because I am not proficient in Scala, but this hopefully illustrates the desired approach.

Context: We run a 300+ server cluster, and perform partial deployments (canary, partial, full).

Requirement: Monitor the aggregate response performance between various clusters of servers delineated by labels that handle the totality of inbound traffic. The labels are server-level as they represent a specific version of one or more running binaries. These labels make for easy comparison between different versions. Unfortunately, the Akka HTTP performance does not currently lend itself to server-level custom labels, and therefore comparing performance is prohibitively expensive to do, since it involves identifying and targeting individual internal server IPs which rotate.

NB: The incremental testing is likely insufficient, I apologize.