### PR TITLE
Fix prometheus label ordering

### DIFF
--- a/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
+++ b/core/src/main/scala/fr/davit/akka/http/metrics/core/HttpMetricsRegistry.scala
@@ -45,11 +45,11 @@ abstract class HttpMetricsRegistry(settings: HttpMetricsSettings) extends HttpMe
     builder.result()
   }
 
-  protected def requestDimensions(request: HttpRequest): Seq[Dimension] = {
+  private def requestDimensions(request: HttpRequest): Seq[Dimension] = {
     requestLabelers.map(_.dimension(request))
   }
 
-  protected def responseDimensions(response: HttpResponse): Seq[Dimension] = {
+  private def responseDimensions(response: HttpResponse): Seq[Dimension] = {
     responseLabelers.map(_.dimension(response))
   }
 


### PR DESCRIPTION
Ordering of the dimensions was non consistent when server dimensions
were set.

Fix #266 

Make a clear split between
- `serverDimensions`
- `requestDimensions`
- `responseDimensions`

Add unit test for ordering to catch undesired change.